### PR TITLE
Fixes for wxPython Phoenix, Python 3.4, and matplotlib wx backend.

### DIFF
--- a/lib/baseframe.py
+++ b/lib/baseframe.py
@@ -128,7 +128,7 @@ Matt Newville <newville@cars.uchicago.edu>""" % __version__
     ####
     def BuildFrame(self):
         # Python3 note: wxPython has no THICK_FRAME
-        sbar = self.CreateStatusBar(2, wx.CAPTION|wx.THICK_FRAME)
+        sbar = self.CreateStatusBar(2)#, wx.CAPTION|wx.THICK_FRAME)
         sfont = sbar.GetFont()
         sfont.SetWeight(wx.BOLD)
         sfont.SetPointSize(10)

--- a/lib/basepanel.py
+++ b/lib/basepanel.py
@@ -473,14 +473,14 @@ class BasePanel(wx.Panel):
         zdc.SetBrush(wx.TRANSPARENT_BRUSH)
         zdc.SetPen(wx.Pen('White', 2, wx.SOLID))
         zdc.ResetBoundingBox()
-        zdc.BeginDrawing()
+#        zdc.BeginDrawing()
 
         # erase previous box
         if self.rbbox is not None:
             zdc.DrawRectangle(*self.rbbox)
         self.rbbox = (x0, y0, width, height)
         zdc.DrawRectangle(*self.rbbox)
-        zdc.EndDrawing()
+#        zdc.EndDrawing()
 
     def zoom_leftdown(self, event=None):
         """leftdown event handler for zoom mode"""

--- a/lib/colors.py
+++ b/lib/colors.py
@@ -323,7 +323,8 @@ def hexcolor(color):
     " returns hex color given a tuple, wx.Color, or X11 named color"
     # first, if this is a hex color already, return!
     # Python 3: needs rewrite for str/unicode change
-    if isinstance(color, (str, unicode)):
+#    if isinstance(color, (str, unicode)):
+    if isinstance(color, str):
         if color[0] == '#' and len(color)==7:
             return color
 
@@ -333,7 +334,8 @@ def hexcolor(color):
         rgb = color
     elif isinstance(color, list):
         rgb = tuple(color)
-    elif isinstance(color, (str, unicode)):
+#    elif isinstance(color, (str, unicode)):
+    elif isinstance(color, str):
         c = color.lower()
         if c.find(' ')>-1:    c = c.replace(' ','')
         if c.find('gray')>-1: c = c.replace('gray','grey')


### PR DESCRIPTION
Fixes for wxPython Phoenix, Python 3.4, and matplotlib wx backend.

In addition to the below, I also had to change matplotlib/backends/backend_wx.py by commenting out these lines:

```
670: #        wx.WXK_PRIOR           : 'pageup',
671: #        wx.WXK_NEXT            : 'pagedown',
694: #        wx.WXK_NUMPAD_PRIOR    : 'pageup',
695: #        wx.WXK_NUMPAD_NEXT     : 'pagedown',
```

Again, essentially no testing was done on these changes, aside from "Oh hey cool it works for me". In addition, the changes were made to wxmplot v0.9.14 which is a little behind the trunk on GitHub. I'm assuming that's been updated in the trunk needs to be changed.