### PR TITLE
Mpl renderer

### DIFF
--- a/.github/workflows/test_wxmplot_install.yml
+++ b/.github/workflows/test_wxmplot_install.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
 
     steps:
     - uses: actions/checkout@v2

--- a/wxmplot/basepanel.py
+++ b/wxmplot/basepanel.py
@@ -516,7 +516,7 @@ class BasePanel(wx.Panel):
         except:
             pass
 
-    def gui_repaint(self, drawDC=None):
+    def gui_repaint(self, drawDC=None, origin=None):
         """
         Update the displayed image on the GUI canvas, using the supplied
         wx.PaintDC device context.
@@ -527,8 +527,7 @@ class BasePanel(wx.Panel):
             drawDC = wx.ClientDC(self.canvas)
 
         bmp = self.canvas.bitmap
-
-        if wx.Platform == '__WXMSW__':
+        if wx.Platform == '__WXMSW__' and origin != 'WXAgg':
             if self.wx_renderer is None:
                 self.set_wx_renderer(self.fig)
             if self.wx_renderer:


### PR DESCRIPTION
This fixes #52, and works around the change of `cached renderer` in the mpl Wx/WxAgg backends.
I did test by hand with matplotlib 3.2, 3.5, and 3.6