### PR TITLE
Adds VisPy-based ImageCanvas and Histogram widgets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,8 @@ dependencies = [
    "pyyaml>=5.0",
    "pyshortcuts>=1.9.5",
    "vispy>=0.16.2",
+   "pyopengl>=3.1.10",
+   "pyopengl-accelerate>=3.1.10",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,9 @@ dependencies = [
    "numpy>=1.26",
    "Pillow>=7.0",
    "pyyaml>=5.0",
-   "pyshortcuts>=1.9.5"]
+   "pyshortcuts>=1.9.5",
+   "vispy>=0.16.2",
+]
 
 [project.urls]
 Homepage = "https://github.com/newville/wxmplot"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,4 +65,4 @@ Tracker = "https://github.com/newville/wxmplot/issues"
 dev = ["build", "twine"]
 doc = ["Sphinx", "jupyter_sphinx", "sphinx-copybutton", "sphinxcontrib-video"]
 test = ["pytest", "pytest-cov", "coverage"]
-all = ["wxmplotls[dev, doc, test]"]
+all = ["wxmplot[dev, doc, test]"]

--- a/wxmplot/__init__.py
+++ b/wxmplot/__init__.py
@@ -43,8 +43,9 @@ from .stackedplotframe import StackedPlotFrame
 from .residualplotframe import ResidualPlotFrame
 from .imagematrixframe import ImageMatrixFrame
 from .plotapp  import PlotApp
-from .image_canvas import ImageCanvas
-from .line_plot  import LinePlot
+from .image_canvas import ImageCanvas, BinMethod
+from .line_plot import LinePlot
+from .histogram import Histogram
 
 if sys.platform.lower() == 'darwin':
     wx.PyApp.IsDisplayAvailable = lambda _: True

--- a/wxmplot/__init__.py
+++ b/wxmplot/__init__.py
@@ -43,6 +43,7 @@ from .stackedplotframe import StackedPlotFrame
 from .residualplotframe import ResidualPlotFrame
 from .imagematrixframe import ImageMatrixFrame
 from .plotapp  import PlotApp
+from .image_canvas import ImageCanvas
 
 if sys.platform.lower() == 'darwin':
     wx.PyApp.IsDisplayAvailable = lambda _: True

--- a/wxmplot/__init__.py
+++ b/wxmplot/__init__.py
@@ -44,6 +44,7 @@ from .residualplotframe import ResidualPlotFrame
 from .imagematrixframe import ImageMatrixFrame
 from .plotapp  import PlotApp
 from .image_canvas import ImageCanvas
+from .line_plot  import LinePlot
 
 if sys.platform.lower() == 'darwin':
     wx.PyApp.IsDisplayAvailable = lambda _: True

--- a/wxmplot/__init__.py
+++ b/wxmplot/__init__.py
@@ -45,7 +45,7 @@ from .imagematrixframe import ImageMatrixFrame
 from .plotapp  import PlotApp
 from .image_canvas import ImageCanvas, BinMethod
 from .line_plot import LinePlot
-from .histogram import Histogram
+from .histogram import Histogram, compute_histogram_data
 
 if sys.platform.lower() == 'darwin':
     wx.PyApp.IsDisplayAvailable = lambda _: True

--- a/wxmplot/colors.py
+++ b/wxmplot/colors.py
@@ -8,6 +8,8 @@ import numpy as np
 from matplotlib.colors import LinearSegmentedColormap, colorConverter
 #from matplotlib.cm import  register_cmap
 from matplotlib import colormaps
+from vispy.color import get_colormap
+from vispy.color.colormap import get_colormaps
 
 from wxutils.colors import (COLORS, GUI_COLORS, GUIColors, X11_COLORS,
                             set_color, DARK_THEME, get_color)
@@ -167,3 +169,29 @@ def wxcol2hex(col):
 
 def mpl2hexcolor(c):
     return hexcolor(mpl_color(c))
+
+
+# VisPy colormap registry 
+_vispy_registry: dict = {}
+
+
+def register_colormap(name: str, colormap) -> None:
+    """Register a VisPy Colormap for use across all wxmplot vispy widgets."""
+    _vispy_registry[name] = colormap
+
+
+def lookup_colormap(name: str):
+    """Return the VisPy Colormap, checking the app registry first. Falls back to VisPy's built-in colormaps."""
+    return _vispy_registry.get(name) or get_colormap(name)
+
+
+def get_colormap_names() -> list:
+    """Return a sorted list of all available colormaps. Includes both built-in VisPy and any registered colormaps."""
+    return sorted(list(get_colormaps()) + list(_vispy_registry))
+
+
+def colormap_color(colormap: str, t: float):
+    """Return a wx.Colour for colormap at normalised position t in [0, 1]."""
+    t = max(0.0, min(1.0, t))
+    rgba = lookup_colormap(colormap)[t].rgba[0]
+    return wx.Colour(int(rgba[0] * 255), int(rgba[1] * 255), int(rgba[2] * 255))

--- a/wxmplot/histogram.py
+++ b/wxmplot/histogram.py
@@ -1,30 +1,398 @@
-#!/usr/bin/python
+"""
+wxmplot Histogram: histogram data computation and a generic histogram widget with 
+draggable range handles and an optional colorbar strip.
+"""
+
+from typing import Callable
 
 import numpy as np
+import wx
+from wxutils.colors import get_color, register_darkdetect
+from wxutils.themes import get_theme
 
-__all__ = ["compute_histogram_data"]
+from wxmplot.colors import lookup_colormap
+
+__all__ = ["compute_histogram_data", "Histogram"]
 
 _DEFAULT_MAX_PIXELS = 500_000
 
 
-def compute_histogram_data(image: np.ndarray, max_pixels: int = _DEFAULT_MAX_PIXELS) -> tuple[np.ndarray, np.ndarray] | tuple[None, None]:
+def compute_histogram_data(
+    image: np.ndarray,
+    max_pixels: int = _DEFAULT_MAX_PIXELS,
+    log_scale: bool = True,
+) -> tuple[np.ndarray, np.ndarray] | tuple[None, None]:
     """Returns (bin_centers, log_counts) for a log-log histogram. Samples up to max_pixels pixels from the image before computing the histogram."""
     flat = image.ravel()
     if flat.size > max_pixels:
         flat = flat[:: flat.size // max_pixels]
     flat = flat.astype(np.float64)
-    positive = flat[flat >= 0]
-    if positive.size == 0:
-        return None, None
 
-    log_data = np.log1p(positive)
-    log_data = log_data[np.isfinite(log_data)]
-    if log_data.size == 0:
-        return None, None
+    if log_scale:
+        positive = flat[flat >= 0]
+        if positive.size == 0:
+            return None, None
+        data = np.log1p(positive)
+        data = data[np.isfinite(data)]
+        if data.size == 0:
+            return None, None
+        hist, bin_edges = np.histogram(data, bins=1500)
+        mask = hist > 0
+        if not mask.any():
+            return None, None
+        return bin_edges[:-1][mask], np.log(hist[mask].astype(np.float64))
+    else:
+        finite = flat[np.isfinite(flat)]
+        if finite.size == 0:
+            return None, None
+        hist, bin_edges = np.histogram(finite, bins=256)
+        mask = hist > 0
+        if not mask.any():
+            return None, None
+        centers = 0.5 * (bin_edges[:-1] + bin_edges[1:])
+        return centers[mask], hist[mask].astype(np.float64)
 
-    hist, bin_edges = np.histogram(log_data, bins=1500)
-    mask = hist > 0
-    if not mask.any():
-        return None, None
 
-    return bin_edges[:-1][mask], np.log(hist[mask].astype(np.float64))
+class Histogram(wx.Panel):
+    """Horizontal histogram with draggable range handles and an optional colorbar strip."""
+
+    def __init__(
+        self,
+        parent: wx.Window,
+        colormap: str = "gray",
+        log_scale: bool = False,
+        show_colorbar: bool = False,
+        on_levels_changed: Callable | None = None,
+        margin_left: int = 30,
+        margin_right: int = 10,
+        margin_top: int = 6,
+        margin_bottom: int = 20,
+        gradient_height: int = 12,
+        gradient_gap: int = 4,
+        handle_radius: int = 6,
+        hit_radius: int = 10,
+    ) -> None:
+        """Initialise the Histogram widget.
+
+        parent:            Parent wx.Window
+        colormap:          Colormap name for the gradient strip (only used when show_colorbar=True)
+        log_scale:         If True, use log-scale axis mapping for intensity images
+        show_colorbar:     If True, draw a colormap gradient strip below the histogram
+        on_levels_changed: Optional callback fired with (min, max) when handles move
+        margin_left:       Left margin in pixels (default 30)
+        margin_right:      Right margin in pixels (default 10)
+        margin_top:        Top margin in pixels (default 6)
+        margin_bottom:     Bottom margin in pixels (default 20)
+        gradient_height:   Height of the colorbar strip in pixels (default 12)
+        gradient_gap:      Gap between histogram and colorbar in pixels (default 4)
+        handle_radius:     Radius of the handle circles in pixels (default 6)
+        hit_radius:        Hit-test radius for handle dragging in pixels (default 10)
+        """
+        super().__init__(parent)
+        self.SetBackgroundStyle(wx.BG_STYLE_PAINT)
+        self.SetMinSize((-1, 80))
+
+        self._colormap = colormap
+        self._log_scale = log_scale
+        self._show_colorbar = show_colorbar
+        self._margin_left = margin_left
+        self._margin_right = margin_right
+        self._margin_top = margin_top
+        self._margin_bottom = margin_bottom
+        self._gradient_height = gradient_height
+        self._gradient_gap = gradient_gap
+        self._handle_radius = handle_radius
+        self._hit_radius = hit_radius
+        self._min_val = 1.0
+        self._max_val = 255.0
+        self._level_min = 1.0
+        self._level_max = 255.0
+        self._bin_centers: np.ndarray | None = None
+        self._counts: np.ndarray | None = None
+        self._gradient_bitmap: wx.Bitmap | None = None
+        self._gradient_bitmap_width: int = 0
+        self._dragging: str | None = None
+        self._drag_start_x: float = 0.0
+        self._drag_start_min: float = 0.0
+        self._drag_start_max: float = 0.0
+        self._on_levels_changed = on_levels_changed
+
+        register_darkdetect(self._on_theme_change)
+
+        self.Bind(wx.EVT_PAINT, self._on_paint)
+        self.Bind(wx.EVT_SIZE, self._on_size)
+        self.Bind(wx.EVT_LEFT_DOWN, self._on_mouse_down)
+        self.Bind(wx.EVT_LEFT_UP, self._on_mouse_up)
+        self.Bind(wx.EVT_MOTION, self._on_mouse_move)
+
+    def set_colormap(self, colormap: str) -> None:
+        """Set the colormap by name and redraw."""
+        self._colormap = colormap
+        self._gradient_bitmap = None
+        self.Refresh()
+
+    def set_data(self, data: np.ndarray, auto_scale: bool = False) -> None:
+        """Update histogram from a data array."""
+        if data is None or data.size == 0:
+            return
+        raw_min = float(data.min())
+        raw_max = float(data.max())
+        new_min = max(raw_min, -1.0) if self._log_scale else raw_min
+        new_max = raw_max if raw_max > new_min else new_min + 1.0
+        self._bin_centers, self._counts = compute_histogram_data(data, log_scale=self._log_scale)
+        self._min_val = new_min
+        self._max_val = new_max
+        if auto_scale or self._level_min >= self._level_max:
+            self._level_min = new_min
+            self._level_max = new_max
+        else:
+            self._level_min = max(self._level_min, new_min)
+            self._level_max = min(self._level_max, new_max)
+        self.Refresh()
+
+    def set_levels(self, min_val: float, max_val: float) -> None:
+        """Set the range handles directly."""
+        self._level_min = min_val
+        self._level_max = max_val
+        self.Refresh()
+
+    def get_levels(self) -> tuple[float, float]:
+        """Return the current min, max handle values."""
+        return self._level_min, self._level_max
+
+    def set_range(self, min_val: float, max_val: float) -> None:
+        """Set the data range shown by the histogram axis."""
+        self._min_val = max(min_val, -1.0) if self._log_scale else min_val
+        self._max_val = max_val if max_val > self._min_val else self._min_val + 1.0
+        self.Refresh()
+
+    def _on_theme_change(self, is_dark: bool = False) -> None:
+        """Repaint when the system theme changes."""
+        self._gradient_bitmap = None
+        self.Refresh()
+
+    def _colorbar_height(self) -> int:
+        """Return the total vertical space reserved for the colorbar strip."""
+        return (self._gradient_height + self._gradient_gap) if self._show_colorbar else 0
+
+    def _plot_rect(self) -> tuple[int, int, int, int]:
+        """Return x, y, w, h of the histogram plot area."""
+        w, h = self.GetSize()
+        pb = h - self._margin_bottom - self._colorbar_height()
+        return self._margin_left, self._margin_top, max(1, w - self._margin_left - self._margin_right), max(1, pb - self._margin_top)
+
+    def _gradient_rect(self) -> tuple[int, int, int, int]:
+        """Return x, y, w, h of the colorbar gradient strip."""
+        w, h = self.GetSize()
+        y = h - self._margin_bottom - self._gradient_height
+        return self._margin_left, y, max(1, w - self._margin_left - self._margin_right), self._gradient_height
+
+    def _val_to_x(self, value: float) -> float:
+        """Map a data value to canvas x coordinate."""
+        pl, _, pw, _ = self._plot_rect()
+        if self._log_scale:
+            v_min = np.log1p(max(self._min_val, 0.0))
+            v_max = np.log1p(max(self._max_val, 0.0))
+            v = np.log1p(max(value, 0.0))
+        else:
+            v_min = self._min_val
+            v_max = self._max_val
+            v = value
+        if v_max == v_min:
+            return pl + pw / 2.0
+        t = max(0.0, min(1.0, (v - v_min) / (v_max - v_min)))
+        return pl + t * pw
+
+    def _x_to_val(self, x: float) -> float:
+        """Map a canvas x coordinate to a data value."""
+        pl, _, pw, _ = self._plot_rect()
+        if self._log_scale:
+            v_min = np.log1p(max(self._min_val, 0.0))
+            v_max = np.log1p(max(self._max_val, 0.0))
+        else:
+            v_min = self._min_val
+            v_max = self._max_val
+        t = max(0.0, min(1.0, (x - pl) / pw))
+        v = v_min + t * (v_max - v_min)
+        return np.expm1(v) if self._log_scale else v
+
+    def _build_gradient_bitmap(self, w: int, h: int) -> wx.Bitmap:
+        """Build a wx.Bitmap of the current colormap gradient."""
+        cmap = lookup_colormap(self._colormap)
+        ts = np.linspace(0.0, 1.0, max(w, 1))
+        rgba = cmap[ts].rgba
+        rgb = (np.clip(rgba[:, :3], 0.0, 1.0) * 255).astype(np.uint8)
+        data = np.ascontiguousarray(np.repeat(rgb[:, np.newaxis, :], h, axis=1).transpose(1, 0, 2))
+        return wx.Bitmap.FromBuffer(w, h, data.tobytes())
+
+    def _fmt_value(self, v: float) -> str:
+        """Format a data value for display as a handle label."""
+        if v == 0:
+            return "0"
+        if abs(v) >= 10000 or (abs(v) < 0.01 and v != 0):
+            return f"{v:.2e}"
+        return f"{int(v):,}" if v == int(v) else f"{v:.1f}"
+
+    def _on_paint(self, _: wx.PaintEvent) -> None:
+        """Paint the histogram, optional colorbar, handles, and labels."""
+        dc = wx.AutoBufferedPaintDC(self)
+        gc = wx.GraphicsContext.Create(dc)
+        if gc is None:
+            return
+
+        bg = get_color("bg")
+        border = get_color("graytext")
+        theme = get_theme()
+        hist_line = wx.Colour(theme.blue.Red(), theme.blue.Green(), theme.blue.Blue())
+        hist_fill = wx.Colour(theme.blue.Red(), theme.blue.Green(), theme.blue.Blue(), 35)
+        region_fill = wx.Colour(theme.blue.Red(), theme.blue.Green(), theme.blue.Blue(), 45)
+        region_hover = wx.Colour(theme.blue.Red(), theme.blue.Green(), theme.blue.Blue(), 70)
+        handle_min = wx.Colour(theme.red.Red(), theme.red.Green(), theme.red.Blue())
+        handle_max = wx.Colour(theme.green.Red(), theme.green.Green(), theme.green.Blue())
+
+        w, h = self.GetSize()
+        pl, pt, pw, ph = self._plot_rect()
+
+        gc.SetBrush(wx.Brush(bg))
+        gc.DrawRectangle(0, 0, w, h)
+
+        if self._show_colorbar:
+            gx, gy, gw, gh = self._gradient_rect()
+            bmp_w, bmp_h = int(gw), int(gh)
+            if bmp_w > 0 and bmp_h > 0:
+                if self._gradient_bitmap is None or self._gradient_bitmap_width != bmp_w:
+                    self._gradient_bitmap = self._build_gradient_bitmap(bmp_w, bmp_h)
+                    self._gradient_bitmap_width = bmp_w
+                gc.DrawBitmap(self._gradient_bitmap, gx, gy, bmp_w, bmp_h)
+            gc.SetPen(wx.Pen(border, 1))
+            gc.SetBrush(wx.TRANSPARENT_BRUSH)
+            gc.DrawRectangle(gx, gy, gw, gh)
+            handle_bottom = gy + gh
+        else:
+            handle_bottom = pt + ph
+
+        if self._bin_centers is not None and self._counts is not None and len(self._bin_centers) > 1:
+            if self._log_scale:
+                v_min = np.log1p(max(self._min_val, 0.0))
+                v_max = np.log1p(max(self._max_val, 0.0))
+            else:
+                v_min = self._min_val
+                v_max = self._max_val
+            v_range = v_max - v_min or 1.0
+            count_range = (self._counts.max() - self._counts.min()) or 1.0
+            count_min = self._counts.min()
+
+            pts = [
+                (pl + max(0.0, min(1.0, (bc - v_min) / v_range)) * pw, pt + ph - (c - count_min) / count_range * ph)
+                for bc, c in zip(self._bin_centers, self._counts)
+            ]
+
+            fill_path = gc.CreatePath()
+            fill_path.MoveToPoint(pts[0][0], pt + ph)
+            for px, py in pts:
+                fill_path.AddLineToPoint(px, py)
+            fill_path.AddLineToPoint(pts[-1][0], pt + ph)
+            fill_path.CloseSubpath()
+            gc.SetBrush(wx.Brush(hist_fill))
+            gc.SetPen(wx.TRANSPARENT_PEN)
+            gc.FillPath(fill_path)
+
+            line_path = gc.CreatePath()
+            line_path.MoveToPoint(pts[0][0], pts[0][1])
+            for px, py in pts[1:]:
+                line_path.AddLineToPoint(px, py)
+            gc.SetPen(wx.Pen(hist_line, 1))
+            gc.SetBrush(wx.TRANSPARENT_BRUSH)
+            gc.StrokePath(line_path)
+
+        min_x = self._val_to_x(self._level_min)
+        max_x = self._val_to_x(self._level_max)
+        rw = max(min_x, max_x) - min(min_x, max_x)
+        if rw > 0:
+            fill_colour = region_hover if self._dragging == "region" else region_fill
+            gc.SetBrush(wx.Brush(fill_colour))
+            gc.SetPen(wx.TRANSPARENT_PEN)
+            gc.DrawRectangle(min(min_x, max_x), pt, rw, ph + self._colorbar_height())
+
+        handle_bg = get_color("bg")
+        for x, col in ((min_x, handle_min), (max_x, handle_max)):
+            gc.SetPen(wx.Pen(col, 1))
+            gc.StrokeLine(x, pt, x, handle_bottom)
+            r = self._handle_radius
+            gc.SetBrush(wx.Brush(col))
+            gc.SetPen(wx.Pen(handle_bg, 1))
+            gc.DrawEllipse(x - r, handle_bottom - r, r * 2, r * 2)
+
+        font = wx.Font(wx.Size(0, 11), wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD)
+        for x, col, val in ((min_x, handle_min, self._level_min), (max_x, handle_max, self._level_max)):
+            gc.SetFont(font, col)
+            lbl = self._fmt_value(val)
+            tw, _ = gc.GetTextExtent(lbl)
+            gc.DrawText(lbl, x - tw / 2, handle_bottom + 2 + self._handle_radius)
+
+    def _on_mouse_down(self, event: wx.MouseEvent) -> None:
+        """Begin dragging a handle or the selection region."""
+        x = event.GetX()
+        min_x = self._val_to_x(self._level_min)
+        max_x = self._val_to_x(self._level_max)
+        if abs(x - min_x) < self._hit_radius:
+            self._dragging = "min"
+            self.CaptureMouse()
+        elif abs(x - max_x) < self._hit_radius:
+            self._dragging = "max"
+            self.CaptureMouse()
+        elif min(min_x, max_x) <= x <= max(min_x, max_x):
+            self._dragging = "region"
+            self._drag_start_x = x
+            self._drag_start_min = self._level_min
+            self._drag_start_max = self._level_max
+            self.CaptureMouse()
+
+    def _on_mouse_up(self, event: wx.MouseEvent) -> None:
+        """Release mouse capture and end drag."""
+        if self._dragging and self.HasCapture():
+            self.ReleaseMouse()
+        self._dragging = None
+        self.Refresh()
+
+    def _on_mouse_move(self, event: wx.MouseEvent) -> None:
+        """Update range handles while dragging."""
+        if not self._dragging:
+            return
+        x = event.GetX()
+        if self._dragging == "region":
+            delta = x - self._drag_start_x
+            if self._log_scale:
+                log_span = np.log1p(max(self._drag_start_max, 0.0)) - np.log1p(max(self._drag_start_min, 0.0))
+                log_dmin = np.log1p(max(self._min_val, 0.0))
+                log_dmax = np.log1p(max(self._max_val, 0.0))
+                new_min = self._x_to_val(self._val_to_x(self._drag_start_min) + delta)
+                lmin = np.log1p(max(new_min, 0.0))
+                lmax = lmin + log_span
+                if lmin < log_dmin:
+                    lmin, lmax = log_dmin, log_dmin + log_span
+                if lmax > log_dmax:
+                    lmax, lmin = log_dmax, log_dmax - log_span
+                self._level_min = np.expm1(lmin)
+                self._level_max = np.expm1(lmax)
+            else:
+                span = self._drag_start_max - self._drag_start_min
+                new_min = self._x_to_val(self._val_to_x(self._drag_start_min) + delta)
+                new_min = max(self._min_val, min(self._max_val - span, new_min))
+                self._level_min = new_min
+                self._level_max = new_min + span
+        else:
+            value = max(self._min_val, min(self._max_val, self._x_to_val(x)))
+            if self._dragging == "min" and value < self._level_max:
+                self._level_min = value
+            elif self._dragging == "max" and value > self._level_min:
+                self._level_max = value
+        self.Refresh()
+        if self._on_levels_changed:
+            self._on_levels_changed(self._level_min, self._level_max)
+
+    def _on_size(self, event: wx.SizeEvent) -> None:
+        """Unset gradient cache on resize."""
+        self._gradient_bitmap = None
+        self.Refresh()
+        event.Skip()

--- a/wxmplot/histogram.py
+++ b/wxmplot/histogram.py
@@ -115,6 +115,7 @@ class Histogram(wx.Panel):
         self._drag_start_x: float = 0.0
         self._drag_start_min: float = 0.0
         self._drag_start_max: float = 0.0
+        self._last_callback_levels: tuple[float, float] | None = None
         self._on_levels_changed = on_levels_changed
 
         register_darkdetect(self._on_theme_change)
@@ -131,27 +132,33 @@ class Histogram(wx.Panel):
         self._gradient_bitmap = None
         self.Refresh()
 
-    def set_data(self, data: np.ndarray, auto_scale: bool = False) -> None:
-        """Update histogram from a data array."""
+    def set_data(self, data: np.ndarray, auto_scale: bool = False, data_range: tuple[float, float] | None = None) -> None:
+        """Update histogram from a data array"""
         if data is None or data.size == 0:
             return
         raw_min = float(data.min())
         raw_max = float(data.max())
-        new_min = max(raw_min, -1.0) if self._log_scale else raw_min
-        new_max = raw_max if raw_max > new_min else new_min + 1.0
+        
+        # Use provided data_range for axis, or fall back to actual data range
+        if data_range is not None:
+            new_min, new_max = data_range
+        else:
+            new_min = raw_min
+            new_max = raw_max if raw_max > raw_min else raw_min + 1.0
+
         self._bin_centers, self._counts = compute_histogram_data(data, log_scale=self._log_scale)
         self._min_val = new_min
         self._max_val = new_max
         if auto_scale or self._level_min >= self._level_max:
             self._level_min = new_min
             self._level_max = new_max
-        else:
-            self._level_min = max(self._level_min, new_min)
-            self._level_max = min(self._level_max, new_max)
         self.Refresh()
 
     def set_levels(self, min_val: float, max_val: float) -> None:
         """Set the range handles directly."""
+        # Ensure handles don't overlap
+        if max_val <= min_val:
+            max_val = min_val + 1.0
         self._level_min = min_val
         self._level_max = max_val
         self.Refresh()
@@ -162,7 +169,7 @@ class Histogram(wx.Panel):
 
     def set_range(self, min_val: float, max_val: float) -> None:
         """Set the data range shown by the histogram axis."""
-        self._min_val = max(min_val, -1.0) if self._log_scale else min_val
+        self._min_val = min_val
         self._max_val = max_val if max_val > self._min_val else self._min_val + 1.0
         self.Refresh()
 
@@ -191,9 +198,16 @@ class Histogram(wx.Panel):
         """Map a data value to canvas x coordinate."""
         pl, _, pw, _ = self._plot_rect()
         if self._log_scale:
-            v_min = np.log1p(max(self._min_val, 0.0))
-            v_max = np.log1p(max(self._max_val, 0.0))
-            v = np.log1p(max(value, 0.0))
+            # Use log scale for positive values, linear for negative
+            if self._min_val >= 0.0:
+                v_min = np.log1p(self._min_val)
+                v_max = np.log1p(self._max_val)
+                v = np.log1p(max(value, 0.0))
+            else:
+                # Mixed range: map linearly when min is negative
+                v_min = self._min_val
+                v_max = self._max_val
+                v = value
         else:
             v_min = self._min_val
             v_max = self._max_val
@@ -207,14 +221,24 @@ class Histogram(wx.Panel):
         """Map a canvas x coordinate to a data value."""
         pl, _, pw, _ = self._plot_rect()
         if self._log_scale:
-            v_min = np.log1p(max(self._min_val, 0.0))
-            v_max = np.log1p(max(self._max_val, 0.0))
+            # Use log scale for positive values, linear for negative
+            if self._min_val >= 0.0:
+                v_min = np.log1p(self._min_val)
+                v_max = np.log1p(self._max_val)
+                t = max(0.0, min(1.0, (x - pl) / pw))
+                v = v_min + t * (v_max - v_min)
+                return np.expm1(v)
+            else:
+                # Mixed range: map linearly when min is negative
+                v_min = self._min_val
+                v_max = self._max_val
+                t = max(0.0, min(1.0, (x - pl) / pw))
+                return v_min + t * (v_max - v_min)
         else:
             v_min = self._min_val
             v_max = self._max_val
-        t = max(0.0, min(1.0, (x - pl) / pw))
-        v = v_min + t * (v_max - v_min)
-        return np.expm1(v) if self._log_scale else v
+            t = max(0.0, min(1.0, (x - pl) / pw))
+            return v_min + t * (v_max - v_min)
 
     def _build_gradient_bitmap(self, w: int, h: int) -> wx.Bitmap:
         """Build a wx.Bitmap of the current colormap gradient."""
@@ -362,12 +386,13 @@ class Histogram(wx.Panel):
         x = event.GetX()
         if self._dragging == "region":
             delta = x - self._drag_start_x
-            if self._log_scale:
-                log_span = np.log1p(max(self._drag_start_max, 0.0)) - np.log1p(max(self._drag_start_min, 0.0))
-                log_dmin = np.log1p(max(self._min_val, 0.0))
-                log_dmax = np.log1p(max(self._max_val, 0.0))
+            if self._log_scale and self._min_val >= 0.0:
+                # Use log scale only for fully positive range
+                log_span = np.log1p(self._drag_start_max) - np.log1p(self._drag_start_min)
+                log_dmin = np.log1p(self._min_val)
+                log_dmax = np.log1p(self._max_val)
                 new_min = self._x_to_val(self._val_to_x(self._drag_start_min) + delta)
-                lmin = np.log1p(max(new_min, 0.0))
+                lmin = np.log1p(new_min)
                 lmax = lmin + log_span
                 if lmin < log_dmin:
                     lmin, lmax = log_dmin, log_dmin + log_span
@@ -376,6 +401,7 @@ class Histogram(wx.Panel):
                 self._level_min = np.expm1(lmin)
                 self._level_max = np.expm1(lmax)
             else:
+                # Use linear scale for negative or mixed ranges
                 span = self._drag_start_max - self._drag_start_min
                 new_min = self._x_to_val(self._val_to_x(self._drag_start_min) + delta)
                 new_min = max(self._min_val, min(self._max_val - span, new_min))
@@ -388,7 +414,10 @@ class Histogram(wx.Panel):
             elif self._dragging == "max" and value > self._level_min:
                 self._level_max = value
         self.Refresh()
-        if self._on_levels_changed:
+        # Only fire callback if the value actually changed
+        current_levels = (self._level_min, self._level_max)
+        if self._on_levels_changed and current_levels != self._last_callback_levels:
+            self._last_callback_levels = current_levels
             self._on_levels_changed(self._level_min, self._level_max)
 
     def _on_size(self, event: wx.SizeEvent) -> None:

--- a/wxmplot/histogram.py
+++ b/wxmplot/histogram.py
@@ -183,6 +183,10 @@ class Histogram(wx.Panel):
         """Return the current min, max handle values."""
         return self._level_min, self._level_max
 
+    def get_range(self) -> tuple[float, float]:
+        """Return the current axis data range."""
+        return self._min_val, self._max_val
+
     def set_range(self, min_val: float, max_val: float) -> None:
         """Set the data range shown by the histogram axis."""
         self._min_val = min_val

--- a/wxmplot/histogram.py
+++ b/wxmplot/histogram.py
@@ -1,5 +1,5 @@
 """
-wxmplot Histogram: histogram data computation and a generic histogram widget with 
+wxmplot Histogram: histogram data computation and a generic histogram widget with
 draggable range handles and an optional colorbar strip.
 """
 
@@ -16,20 +16,21 @@ from wxmplot.colors import lookup_colormap
 __all__ = ["compute_histogram_data", "Histogram"]
 
 _DEFAULT_MAX_PIXELS = 500_000
+_NORMS = ("linear", "sqrt", "log")
 
 
 def compute_histogram_data(
     image: np.ndarray,
     max_pixels: int = _DEFAULT_MAX_PIXELS,
-    log_scale: bool = True,
+    norm: str = "linear",
 ) -> tuple[np.ndarray, np.ndarray] | tuple[None, None]:
-    """Returns (bin_centers, log_counts) for a log-log histogram. Samples up to max_pixels pixels from the image before computing the histogram."""
+    """Returns (bin_centers, counts) with both axes in the norm-transformed space."""
     flat = image.ravel()
     if flat.size > max_pixels:
         flat = flat[:: flat.size // max_pixels]
     flat = flat.astype(np.float64)
 
-    if log_scale:
+    if norm == "log":
         positive = flat[flat > 0]
         if positive.size == 0:
             return None, None
@@ -42,7 +43,21 @@ def compute_histogram_data(
         if not mask.any():
             return None, None
         return bin_edges[:-1][mask], np.log(hist[mask].astype(np.float64))
-    else:
+    elif norm == "sqrt":
+        nonneg = flat[flat >= 0]
+        if nonneg.size == 0:
+            return None, None
+        data = np.sqrt(nonneg)
+        data = data[np.isfinite(data)]
+        if data.size == 0:
+            return None, None
+        hist, bin_edges = np.histogram(data, bins=512)
+        mask = hist > 0
+        if not mask.any():
+            return None, None
+        centers = 0.5 * (bin_edges[:-1] + bin_edges[1:])
+        return centers[mask], np.sqrt(hist[mask].astype(np.float64))
+    else:  # linear
         finite = flat[np.isfinite(flat)]
         if finite.size == 0:
             return None, None
@@ -61,7 +76,7 @@ class Histogram(wx.Panel):
         self,
         parent: wx.Window,
         colormap: str = "gray",
-        log_scale: bool = False,
+        norm: str = "linear",
         show_colorbar: bool = False,
         on_levels_changed: Callable | None = None,
         margin_left: int = 30,
@@ -77,7 +92,7 @@ class Histogram(wx.Panel):
 
         parent:            Parent wx.Window
         colormap:          Colormap name for the gradient strip (only used when show_colorbar=True)
-        log_scale:         If True, use log-scale axis mapping for intensity images
+        norm:              Sets the normilization (default linear)
         show_colorbar:     If True, draw a colormap gradient strip below the histogram
         on_levels_changed: Optional callback fired with (min, max) when handles move
         margin_left:       Left margin in pixels (default 30)
@@ -94,7 +109,7 @@ class Histogram(wx.Panel):
         self.SetMinSize((-1, 80))
 
         self._colormap = colormap
-        self._log_scale = log_scale
+        self._norm = norm
         self._show_colorbar = show_colorbar
         self._margin_left = margin_left
         self._margin_right = margin_right
@@ -133,38 +148,51 @@ class Histogram(wx.Panel):
         self._gradient_bitmap = None
         self.Refresh()
 
-    def set_data(self, data: np.ndarray, auto_scale: bool = False, data_range: tuple[float, float] | None = None) -> None:
-        """Update histogram from a data array"""
+    def set_norm(self, norm: str) -> None:
+        """Change the axis normalization and clear cached histogram data."""
+        if norm not in _NORMS:
+            raise ValueError(f"norm must be one of {_NORMS}, got {norm!r}")
+        if norm == self._norm:
+            return
+        self._norm = norm
+        self._bin_centers = None
+        self._counts = None
+        self.Refresh()
+
+    @property
+    def norm(self) -> str:
+        return self._norm
+
+    def set_data(self, data: np.ndarray, auto_scale: bool = False) -> None:
+        """Update histogram from a data array."""
         if data is None or data.size == 0:
             return
 
         # Use provided data_range for axis, or fall back to actual data range
         flat = data.ravel().astype(np.float64)
+        self._bin_centers, self._counts = compute_histogram_data(flat, norm=self._norm)
 
-        if data_range is not None:
-            new_min, new_max = data_range
-            use_log = self._log_scale and new_min >= 0
-        elif self._log_scale:
-            # Always use positive pixels for log-scale detector images.
-            # Negative pixels (gap/masked pixels) are excluded from the axis and histogram.
-            positive = flat[flat > 0]
-            if positive.size == 0:
-                return
-            raw_min = float(positive.min())
-            raw_max = float(positive.max())
-            new_min = raw_min
-            new_max = raw_max if raw_max > raw_min else raw_min + 1.0
-            use_log = True
+        if self._bin_centers is None or len(self._bin_centers) == 0:
+            return
+
+        # Range from actual bin extent so bars always fill the full plot width
+        n = len(self._bin_centers)
+        half_bin = (float(self._bin_centers[-1]) - float(self._bin_centers[0])) / (2 * max(n - 1, 1))
+        lo_t = float(self._bin_centers[0]) - half_bin
+        hi_t = float(self._bin_centers[-1]) + half_bin
+
+        if self._norm == "log":
+            new_min = float(np.expm1(max(lo_t, 0.0)))
+            new_max = float(np.expm1(hi_t))
+        elif self._norm == "sqrt":
+            new_min = float(max(lo_t, 0.0) ** 2)
+            new_max = float(hi_t ** 2)
         else:
-            actual_min = float(flat.min())
-            actual_max = float(flat.max())
-            new_min = actual_min
-            new_max = actual_max if actual_max > actual_min else actual_min + 1.0
-            use_log = False
+            new_min = lo_t
+            new_max = hi_t
 
-        self._bin_centers, self._counts = compute_histogram_data(flat, log_scale=use_log)
         self._min_val = new_min
-        self._max_val = new_max
+        self._max_val = new_max if new_max > new_min else new_min + 1.0
         if auto_scale or self._level_min >= self._level_max:
             self._level_min = new_min
             self._level_max = new_max
@@ -193,6 +221,26 @@ class Histogram(wx.Panel):
         self._max_val = max_val if max_val > self._min_val else self._min_val + 1.0
         self.Refresh()
 
+    def _norm_fwd(self, value: float) -> float:
+        """Map a raw data value into the display (transformed) space."""
+        if self._norm == "log" and self._min_val >= 0:
+            return float(np.log1p(max(value, 0.0)))
+        if self._norm == "sqrt" and self._min_val >= 0:
+            return float(np.sqrt(max(value, 0.0)))
+        return value
+
+    def _norm_range(self) -> tuple[float, float]:
+        """Return (v_min, v_max) in the display space."""
+        return self._norm_fwd(self._min_val), self._norm_fwd(self._max_val)
+
+    def _norm_inv(self, v: float) -> float:
+        """Map a display-space value back to raw data space."""
+        if self._norm == "log" and self._min_val >= 0:
+            return float(np.expm1(v))
+        if self._norm == "sqrt" and self._min_val >= 0:
+            return float(v * v)
+        return v
+
     def _on_theme_change(self, is_dark: bool = False) -> None:
         """Repaint when the system theme changes."""
         self._gradient_bitmap = None
@@ -217,21 +265,8 @@ class Histogram(wx.Panel):
     def _val_to_x(self, value: float) -> float:
         """Map a data value to canvas x coordinate."""
         pl, _, pw, _ = self._plot_rect()
-        if self._log_scale:
-            # Use log scale for positive values, linear for negative
-            if self._min_val >= 0.0:
-                v_min = np.log1p(self._min_val)
-                v_max = np.log1p(self._max_val)
-                v = np.log1p(max(value, 0.0))
-            else:
-                # Mixed range: map linearly when min is negative
-                v_min = self._min_val
-                v_max = self._max_val
-                v = value
-        else:
-            v_min = self._min_val
-            v_max = self._max_val
-            v = value
+        v_min, v_max = self._norm_range()
+        v = self._norm_fwd(value)
         if v_max == v_min:
             return pl + pw / 2.0
         t = max(0.0, min(1.0, (v - v_min) / (v_max - v_min)))
@@ -240,25 +275,10 @@ class Histogram(wx.Panel):
     def _x_to_val(self, x: float) -> float:
         """Map a canvas x coordinate to a data value."""
         pl, _, pw, _ = self._plot_rect()
-        if self._log_scale:
-            # Use log scale for positive values, linear for negative
-            if self._min_val >= 0.0:
-                v_min = np.log1p(self._min_val)
-                v_max = np.log1p(self._max_val)
-                t = max(0.0, min(1.0, (x - pl) / pw))
-                v = v_min + t * (v_max - v_min)
-                return np.expm1(v)
-            else:
-                # Mixed range: map linearly when min is negative
-                v_min = self._min_val
-                v_max = self._max_val
-                t = max(0.0, min(1.0, (x - pl) / pw))
-                return v_min + t * (v_max - v_min)
-        else:
-            v_min = self._min_val
-            v_max = self._max_val
-            t = max(0.0, min(1.0, (x - pl) / pw))
-            return v_min + t * (v_max - v_min)
+        t = max(0.0, min(1.0, (x - pl) / pw))
+        v_min, v_max = self._norm_range()
+        v = v_min + t * (v_max - v_min)
+        return self._norm_inv(v)
 
     def _build_gradient_bitmap(self, w: int, h: int) -> wx.Bitmap:
         """Build a wx.Bitmap of the current colormap gradient."""
@@ -320,12 +340,7 @@ class Histogram(wx.Panel):
             handle_bottom = pt + ph
 
         if self._bin_centers is not None and self._counts is not None and len(self._bin_centers) > 1:
-            if self._log_scale and self._min_val >= 0:
-                v_min = np.log1p(self._min_val)
-                v_max = np.log1p(self._max_val)
-            else:
-                v_min = self._min_val
-                v_max = self._max_val
+            v_min, v_max = self._norm_range()
             v_range = v_max - v_min or 1.0
             count_range = (self._counts.max() - self._counts.min()) or 1.0
             count_min = self._counts.min()
@@ -410,22 +425,19 @@ class Histogram(wx.Panel):
         x = event.GetX()
         if self._dragging == "region":
             delta = x - self._drag_start_x
-            if self._log_scale and self._min_val >= 0.0:
-                # Use log scale only for fully positive range
-                log_span = np.log1p(self._drag_start_max) - np.log1p(self._drag_start_min)
-                log_dmin = np.log1p(self._min_val)
-                log_dmax = np.log1p(self._max_val)
+            if self._norm != "linear" and self._min_val >= 0.0:
+                v_min, v_max = self._norm_range()
+                span = self._norm_fwd(self._drag_start_max) - self._norm_fwd(self._drag_start_min)
                 new_min = self._x_to_val(self._val_to_x(self._drag_start_min) + delta)
-                lmin = np.log1p(new_min)
-                lmax = lmin + log_span
-                if lmin < log_dmin:
-                    lmin, lmax = log_dmin, log_dmin + log_span
-                if lmax > log_dmax:
-                    lmax, lmin = log_dmax, log_dmax - log_span
-                self._level_min = np.expm1(lmin)
-                self._level_max = np.expm1(lmax)
+                t_min = self._norm_fwd(new_min)
+                t_max = t_min + span
+                if t_min < v_min:
+                    t_min, t_max = v_min, v_min + span
+                if t_max > v_max:
+                    t_max, t_min = v_max, v_max - span
+                self._level_min = self._norm_inv(t_min)
+                self._level_max = self._norm_inv(t_max)
             else:
-                # Use linear scale for negative or mixed ranges
                 span = self._drag_start_max - self._drag_start_min
                 new_min = self._x_to_val(self._val_to_x(self._drag_start_min) + delta)
                 new_min = max(self._min_val, min(self._max_val - span, new_min))

--- a/wxmplot/histogram.py
+++ b/wxmplot/histogram.py
@@ -29,7 +29,7 @@ def compute_histogram_data(
     flat = flat.astype(np.float64)
 
     if log_scale:
-        positive = flat[flat >= 0]
+        positive = flat[flat > 0]
         if positive.size == 0:
             return None, None
         data = np.log1p(positive)
@@ -136,13 +136,20 @@ class Histogram(wx.Panel):
         """Update histogram from a data array"""
         if data is None or data.size == 0:
             return
-        raw_min = float(data.min())
-        raw_max = float(data.max())
-        
+
         # Use provided data_range for axis, or fall back to actual data range
         if data_range is not None:
             new_min, new_max = data_range
         else:
+            flat = data.ravel()
+            if self._log_scale:
+                # Exclude zero/gap pixels so the axis spans the actual signal range
+                nonzero = flat[flat > 0]
+                raw_min = float(nonzero.min()) if nonzero.size > 0 else float(flat.min())
+                raw_max = float(flat.max())
+            else:
+                raw_min = float(flat.min())
+                raw_max = float(flat.max())
             new_min = raw_min
             new_max = raw_max if raw_max > raw_min else raw_min + 1.0
 
@@ -253,9 +260,11 @@ class Histogram(wx.Panel):
         """Format a data value for display as a handle label."""
         if v == 0:
             return "0"
-        if abs(v) >= 10000 or (abs(v) < 0.01 and v != 0):
-            return f"{v:.2e}"
-        return f"{int(v):,}" if v == int(v) else f"{v:.1f}"
+        av = abs(v)
+        if v == int(v) and av < 1e15:
+            n = int(v)
+            return f"{n:,}" if av >= 1_000_000 else str(n)
+        return f"{v:.4g}"
 
     def _on_paint(self, _: wx.PaintEvent) -> None:
         """Paint the histogram, optional colorbar, handles, and labels."""

--- a/wxmplot/histogram.py
+++ b/wxmplot/histogram.py
@@ -89,7 +89,7 @@ class Histogram(wx.Panel):
         handle_radius:     Radius of the handle circles in pixels (default 6)
         hit_radius:        Hit-test radius for handle dragging in pixels (default 10)
         """
-        super().__init__(parent)
+        super().__init__(parent, style=wx.BORDER_NONE)
         self.SetBackgroundStyle(wx.BG_STYLE_PAINT)
         self.SetMinSize((-1, 80))
 

--- a/wxmplot/histogram.py
+++ b/wxmplot/histogram.py
@@ -3,6 +3,7 @@ wxmplot Histogram: histogram data computation and a generic histogram widget wit
 draggable range handles and an optional colorbar strip.
 """
 
+import math
 from typing import Callable
 
 import numpy as np
@@ -258,6 +259,8 @@ class Histogram(wx.Panel):
 
     def _fmt_value(self, v: float) -> str:
         """Format a data value for display as a handle label."""
+        if not math.isfinite(v):
+            return ""
         if v == 0:
             return "0"
         av = abs(v)

--- a/wxmplot/histogram.py
+++ b/wxmplot/histogram.py
@@ -139,22 +139,30 @@ class Histogram(wx.Panel):
             return
 
         # Use provided data_range for axis, or fall back to actual data range
+        flat = data.ravel().astype(np.float64)
+
         if data_range is not None:
             new_min, new_max = data_range
-        else:
-            flat = data.ravel()
-            if self._log_scale:
-                # Exclude zero/gap pixels so the axis spans the actual signal range
-                nonzero = flat[flat > 0]
-                raw_min = float(nonzero.min()) if nonzero.size > 0 else float(flat.min())
-                raw_max = float(flat.max())
-            else:
-                raw_min = float(flat.min())
-                raw_max = float(flat.max())
+            use_log = self._log_scale and new_min >= 0
+        elif self._log_scale:
+            # Always use positive pixels for log-scale detector images.
+            # Negative pixels (gap/masked pixels) are excluded from the axis and histogram.
+            positive = flat[flat > 0]
+            if positive.size == 0:
+                return
+            raw_min = float(positive.min())
+            raw_max = float(positive.max())
             new_min = raw_min
             new_max = raw_max if raw_max > raw_min else raw_min + 1.0
+            use_log = True
+        else:
+            actual_min = float(flat.min())
+            actual_max = float(flat.max())
+            new_min = actual_min
+            new_max = actual_max if actual_max > actual_min else actual_min + 1.0
+            use_log = False
 
-        self._bin_centers, self._counts = compute_histogram_data(data, log_scale=self._log_scale)
+        self._bin_centers, self._counts = compute_histogram_data(flat, log_scale=use_log)
         self._min_val = new_min
         self._max_val = new_max
         if auto_scale or self._level_min >= self._level_max:
@@ -308,9 +316,9 @@ class Histogram(wx.Panel):
             handle_bottom = pt + ph
 
         if self._bin_centers is not None and self._counts is not None and len(self._bin_centers) > 1:
-            if self._log_scale:
-                v_min = np.log1p(max(self._min_val, 0.0))
-                v_max = np.log1p(max(self._max_val, 0.0))
+            if self._log_scale and self._min_val >= 0:
+                v_min = np.log1p(self._min_val)
+                v_max = np.log1p(self._max_val)
             else:
                 v_min = self._min_val
                 v_max = self._max_val

--- a/wxmplot/histogram.py
+++ b/wxmplot/histogram.py
@@ -1,0 +1,30 @@
+#!/usr/bin/python
+
+import numpy as np
+
+__all__ = ["compute_histogram_data"]
+
+_DEFAULT_MAX_PIXELS = 500_000
+
+
+def compute_histogram_data(image: np.ndarray, max_pixels: int = _DEFAULT_MAX_PIXELS) -> tuple[np.ndarray, np.ndarray] | tuple[None, None]:
+    """Returns (bin_centers, log_counts) for a log-log histogram. Samples up to max_pixels pixels from the image before computing the histogram."""
+    flat = image.ravel()
+    if flat.size > max_pixels:
+        flat = flat[:: flat.size // max_pixels]
+    flat = flat.astype(np.float64)
+    positive = flat[flat >= 0]
+    if positive.size == 0:
+        return None, None
+
+    log_data = np.log1p(positive)
+    log_data = log_data[np.isfinite(log_data)]
+    if log_data.size == 0:
+        return None, None
+
+    hist, bin_edges = np.histogram(log_data, bins=1500)
+    mask = hist > 0
+    if not mask.any():
+        return None, None
+
+    return bin_edges[:-1][mask], np.log(hist[mask].astype(np.float64))

--- a/wxmplot/image_canvas.py
+++ b/wxmplot/image_canvas.py
@@ -116,6 +116,7 @@ class ImageCanvas(wx.Panel):
         self.Bind(wx.EVT_TIMER, self._on_redraw_tick, self._redraw_timer)
 
         self._bin_method = BinMethod.NONE
+        self._display_shape: tuple[int, int] | None = None
 
         self._panning = False
         self._last_mouse_pos = None
@@ -249,11 +250,12 @@ class ImageCanvas(wx.Panel):
         self._bin_method = method
         if self._raw_image is not None:
             self._apply_image(self._raw_image)
+            self.reset_view()
 
     def reset_view(self) -> None:
         """Reset pan/zoom to fit the image and clear any active ROI."""
-        if self._raw_image is not None:
-            h, w = self._raw_image.shape[:2]
+        if self._display_shape is not None:
+            h, w = self._display_shape
             self._view.camera.set_range(x=(0, w), y=(0, h))
         self._roi_img_coords = None
         self._roi_line.visible = False
@@ -367,6 +369,7 @@ class ImageCanvas(wx.Panel):
             self._data_min, self._data_max = self._min_value, self._max_value
             self._image_visual.clim = (self._min_value, self._max_value)
 
+        self._display_shape = gpu_image.shape[:2]
         self._image_visual.set_data(gpu_image)
         if self._first_image:
             self.reset_view()

--- a/wxmplot/image_canvas.py
+++ b/wxmplot/image_canvas.py
@@ -14,7 +14,7 @@ import wx
 from wxmplot.vispy_utils import vispy_colour, vispy_init, vsync_for_platform
 from wxmplot.colors import lookup_colormap
 from wxutils.themes import get_theme
-from wxutils.colors import register_darkdetect
+from wxutils.colors import get_color, register_darkdetect
 
 vispy_init()
 
@@ -85,6 +85,7 @@ class ImageCanvas(wx.Panel):
             app="wx",
             vsync=vsync_for_platform(),
             size=(100, 100),
+            bgcolor=tuple(c / 255 for c in get_color("bg")),
             config={"samples": 0, "double_buffer": True, "depth_size": 0, "stencil_size": 0},
         )
         self._view = self._canvas.central_widget.add_view()
@@ -298,6 +299,7 @@ class ImageCanvas(wx.Panel):
 
     def _on_theme_change(self, is_dark: bool = False) -> None:
         """Update VisPy visual colours when the system theme changes."""
+        self._canvas.bgcolor = tuple(c / 255 for c in get_color("bg"))
         self._roi_line.set_data(color=vispy_colour("plot_selection"))
         self._line_visual.set_data(color=self._theme_yellow(200))
         self._pixel_info_text.color = self._theme_green(255)

--- a/wxmplot/image_canvas.py
+++ b/wxmplot/image_canvas.py
@@ -4,20 +4,21 @@ wxmplot ImageCanvas: a generic hardware-accelerated image viewer widget using Vi
 with pan/zoom, ROI selection, line ROI, and pixel info overlay.
 """
 
-import sys
 import time
 from enum import StrEnum
 from typing import Callable
 
 import numpy as np
-import vispy
 import wx
 
-vispy.use(app="wx", gl="glplus" if sys.platform == "win32" else "gl2")
+from wxmplot.vispy_utils import vispy_colour, vispy_init, vsync_for_platform
+from wxmplot.colors import lookup_colormap
+from wxutils.themes import get_theme
+from wxutils.colors import register_darkdetect
+
+vispy_init()
 
 from vispy import scene  # noqa: E402
-
-from wxmplot.colors import lookup_colormap
 
 __all__ = ["ImageCanvas", "BinMethod"]
 
@@ -82,7 +83,7 @@ class ImageCanvas(wx.Panel):
             keys=None,
             parent=self,
             app="wx",
-            vsync=True,
+            vsync=vsync_for_platform(),
             size=(100, 100),
             config={"samples": 0, "double_buffer": True, "depth_size": 0, "stencil_size": 0},
         )
@@ -138,7 +139,7 @@ class ImageCanvas(wx.Panel):
 
         self._roi_line = scene.visuals.Line(
             pos=np.array([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]], dtype=np.float32),
-            color=(99 / 255, 179 / 255, 237 / 255, 180 / 255),
+            color=vispy_colour("plot_selection"),
             width=2,
             method="gl",
             parent=self._view.scene,
@@ -147,7 +148,7 @@ class ImageCanvas(wx.Panel):
 
         self._line_visual = scene.visuals.Line(
             pos=np.array([[0, 0], [1, 1]], dtype=np.float32),
-            color=(237 / 255, 179 / 255, 99 / 255, 200 / 255),
+            color=self._theme_yellow(200),
             width=2,
             method="gl",
             parent=self._view.scene,
@@ -165,7 +166,7 @@ class ImageCanvas(wx.Panel):
 
         self._pixel_info_text = scene.visuals.Text(
             text="",
-            color=(72 / 255, 199 / 255, 116 / 255, 1.0),
+            color=self._theme_green(255),
             font_size=8,
             bold=True,
             anchor_x="left",
@@ -178,6 +179,8 @@ class ImageCanvas(wx.Panel):
         sizer.Add(self._canvas.native, 1, wx.EXPAND)
         self.SetSizer(sizer)
         self._canvas.show()
+
+        register_darkdetect(self._on_theme_change)
 
         self._canvas.native.Bind(wx.EVT_MOUSEWHEEL, self._on_mouse_wheel)
         self._canvas.native.Bind(wx.EVT_LEFT_DOWN, self._on_left_down)
@@ -281,6 +284,23 @@ class ImageCanvas(wx.Panel):
         """Register a callback with (x1, y1, x2, y2) when the line ROI changes."""
         self._on_line_changed = callback
 
+    def _theme_yellow(self, alpha: int) -> tuple:
+        """Return the theme yellow as a normalised (r, g, b, a) float tuple for VisPy."""
+        c = get_theme().yellow
+        return (c.Red() / 255, c.Green() / 255, c.Blue() / 255, alpha / 255)
+
+    def _theme_green(self, alpha: int) -> tuple:
+        """Return the theme green as a normalised (r, g, b, a) float tuple for VisPy."""
+        c = get_theme().green
+        return (c.Red() / 255, c.Green() / 255, c.Blue() / 255, alpha / 255)
+
+    def _on_theme_change(self, is_dark: bool = False) -> None:
+        """Update VisPy visual colours when the system theme changes."""
+        self._roi_line.set_data(color=vispy_colour("plot_selection"))
+        self._line_visual.set_data(color=self._theme_yellow(200))
+        self._pixel_info_text.color = self._theme_green(255)
+        self._canvas.update()
+
     def _on_redraw_tick(self, _: wx.TimerEvent) -> None:
         """Apply the latest pending frame and re-arm the timer if more arrived."""
         image = self._pending_image
@@ -378,10 +398,11 @@ class ImageCanvas(wx.Panel):
 
     def _set_line_start_marker(self, x: float, y: float) -> None:
         """Place and show the line start marker at the given image coordinate."""
+        c = self._theme_yellow(255)
         self._line_start_marker.set_data(
             pos=np.array([[x, y, 0]], dtype=np.float32),
-            face_color=(237 / 255, 179 / 255, 99 / 255, 1.0),
-            edge_color=(237 / 255, 179 / 255, 99 / 255, 1.0),
+            face_color=c,
+            edge_color=c,
             size=8,
         )
         self._line_start_marker.visible = True

--- a/wxmplot/image_canvas.py
+++ b/wxmplot/image_canvas.py
@@ -168,7 +168,7 @@ class ImageCanvas(wx.Panel):
         self._pixel_info_text = scene.visuals.Text(
             text="",
             color=self._theme_green(255),
-            font_size=8,
+            font_size=6,
             bold=True,
             anchor_x="left",
             anchor_y="top",

--- a/wxmplot/image_canvas.py
+++ b/wxmplot/image_canvas.py
@@ -116,6 +116,7 @@ class ImageCanvas(wx.Panel):
         self.Bind(wx.EVT_TIMER, self._on_redraw_tick, self._redraw_timer)
 
         self._bin_method = BinMethod.NONE
+        self._norm: str = "linear"
         self._display_shape: tuple[int, int] | None = None
 
         self._panning = False
@@ -220,11 +221,11 @@ class ImageCanvas(wx.Panel):
             self._redraw_timer.StartOnce(self._redraw_interval_ms)
 
     def set_contrast(self, min_val: float, max_val: float) -> None:
-        """Set contrast limits and disable auto-scaling."""
+        """Set contrast limits (raw pixels) and disable auto-scaling."""
         self._auto_scale = False
         self._min_value = min_val
         self._max_value = max_val
-        self._image_visual.clim = (min_val, max_val)
+        self._image_visual.clim = (self._norm_fwd(min_val), self._norm_fwd(max_val))
         self._canvas.update()
 
     def set_auto_scale(self, enabled: bool) -> None:
@@ -232,7 +233,7 @@ class ImageCanvas(wx.Panel):
         self._auto_scale = enabled
         if enabled and self._raw_image is not None:
             self._min_value, self._max_value = self._compute_auto_clim(self._raw_image)
-            self._image_visual.clim = (self._min_value, self._max_value)
+            self._image_visual.clim = (self._norm_fwd(self._min_value), self._norm_fwd(self._max_value))
             self._canvas.update()
 
     def set_filter_gaps(self, enabled: bool) -> None:
@@ -251,6 +252,28 @@ class ImageCanvas(wx.Panel):
         if self._raw_image is not None:
             self._apply_image(self._raw_image)
             self.reset_view()
+
+    def set_norm(self, norm: str) -> None:
+        """Set the display normalization ('linear', 'sqrt', or 'log')."""
+        self._norm = norm
+        if self._raw_image is not None:
+            self._apply_image(self._raw_image)
+
+    def _norm_fwd(self, value: float) -> float:
+        """Convert a raw pixel value to the normalized display space."""
+        if self._norm == "log":
+            return float(np.log1p(max(value, 0.0)))
+        if self._norm == "sqrt":
+            return float(np.sqrt(max(value, 0.0)))
+        return float(value)
+
+    def _norm_apply(self, image: np.ndarray) -> np.ndarray:
+        """Apply the norm transform to an image array for GPU upload."""
+        if self._norm == "log":
+            return np.log1p(np.maximum(image.astype(np.float32), 0.0))
+        if self._norm == "sqrt":
+            return np.sqrt(np.maximum(image.astype(np.float32), 0.0))
+        return image.astype(np.float32) if image.dtype != np.float32 else image
 
     def reset_view(self) -> None:
         """Reset pan/zoom to fit the image and clear any active ROI."""
@@ -364,13 +387,14 @@ class ImageCanvas(wx.Panel):
         if not gpu_image.flags.c_contiguous:
             gpu_image = np.ascontiguousarray(gpu_image)
 
+        self._data_min, self._data_max = self._compute_full_range(full_res)
         if self._auto_scale:
             self._min_value, self._max_value = self._compute_auto_clim(full_res)
-            self._data_min, self._data_max = self._min_value, self._max_value
-            self._image_visual.clim = (self._min_value, self._max_value)
 
-        self._display_shape = gpu_image.shape[:2]
-        self._image_visual.set_data(gpu_image)
+        display_image = self._norm_apply(gpu_image)
+        self._display_shape = display_image.shape[:2]
+        self._image_visual.set_data(display_image)
+        self._image_visual.clim = (self._norm_fwd(self._min_value), self._norm_fwd(self._max_value))
         if self._first_image:
             self.reset_view()
             self._first_image = False
@@ -413,6 +437,20 @@ class ImageCanvas(wx.Panel):
         if vmax <= vmin:
             vmax = vmin + 1.0
         
+        return vmin, vmax
+
+    def _compute_full_range(self, img: np.ndarray) -> tuple[float, float]:
+        """Return the true (sampled) min/max of the image, excluding gaps if filter_gaps is on."""
+        flat = img.reshape(-1)
+        step = max(1, flat.size // self._AUTO_CLIM_SAMPLE_BUDGET)
+        sample = flat[::step]
+        if self._filter_gaps:
+            sample = sample[sample > 0]
+        if sample.size == 0:
+            return 0.0, 1.0
+        vmin, vmax = float(sample.min()), float(sample.max())
+        if vmax <= vmin:
+            vmax = vmin + 1.0
         return vmin, vmax
 
     def _screen_to_image(self, sx: int, sy: int) -> tuple[float, float] | None:

--- a/wxmplot/image_canvas.py
+++ b/wxmplot/image_canvas.py
@@ -176,6 +176,17 @@ class ImageCanvas(wx.Panel):
         )
         self._pixel_info_text.visible = False
 
+        self._fps_text = scene.visuals.Text(
+            text="",
+            color=vispy_colour("green"),
+            font_size=6,
+            bold=True,
+            anchor_x="left",
+            anchor_y="top",
+            parent=self._canvas.scene,
+        )
+        self._fps_text.visible = False
+
         sizer = wx.BoxSizer(wx.VERTICAL)
         sizer.Add(self._canvas.native, 1, wx.EXPAND)
         self.SetSizer(sizer)
@@ -264,6 +275,17 @@ class ImageCanvas(wx.Panel):
     def get_contrast_range(self) -> tuple[float, float]:
         """Return the current contrast (min, max) limits."""
         return self._min_value, self._max_value
+
+    def set_fps(self, fps: float | None) -> None:
+        """Update the FPS overlay in the top-left corner. Pass None to hide."""
+        if fps is None:
+            self._fps_text.visible = False
+            return
+        canvas_h = self._canvas.size[1]
+        self._fps_text.text = f"{fps:.1f} fps"
+        self._fps_text.pos = (8, 12)
+        self._fps_text.visible = True
+        self._canvas.update()
 
     def format_pixel_info(self, ix: int, iy: int, intensity: float) -> str:
         """Return the pixel info string shown in the overlay. Override in a subclass to append specific fields."""

--- a/wxmplot/image_canvas.py
+++ b/wxmplot/image_canvas.py
@@ -554,8 +554,12 @@ class ImageCanvas(wx.Panel):
                         self._on_roi_changed(x1, y1, x2, y2)
                 else:
                     self._roi_line.visible = False
+                    if self._on_roi_cleared:
+                        self._on_roi_cleared()
             else:
                 self._roi_line.visible = False
+                if self._on_roi_cleared:
+                    self._on_roi_cleared()
 
         self._roi_selecting = False
         self._roi_start = None

--- a/wxmplot/image_canvas.py
+++ b/wxmplot/image_canvas.py
@@ -224,10 +224,12 @@ class ImageCanvas(wx.Panel):
         if self._auto_scale and self._raw_image is not None:
             self.set_auto_scale(True)
 
-    def set_bin_method(self, method: BinMethod) -> None:
-        """Switch the live downsampling method; must be a BinMethod value."""
-        if not isinstance(method, BinMethod):
-            raise ValueError(f"Unknown bin method: {method!r}; expected a BinMethod value")
+    def set_bin_method(self, method: BinMethod | str) -> None:
+        """Switch the live downsampling method; accepts a BinMethod value or a plain string."""
+        try:
+            method = BinMethod(method)
+        except ValueError:
+            raise ValueError(f"Unknown bin method: {method!r}; expected one of {[m.value for m in BinMethod]}")
         self._bin_method = method
         if self._raw_image is not None:
             self._apply_image(self._raw_image)

--- a/wxmplot/image_canvas.py
+++ b/wxmplot/image_canvas.py
@@ -276,6 +276,11 @@ class ImageCanvas(wx.Panel):
         """Return the current contrast (min, max) limits."""
         return self._min_value, self._max_value
 
+    def render_to_array(self) -> np.ndarray:
+        """Return the current canvas content as an RGB numpy array (H, W, 3)."""
+        rgba = self._canvas.render()
+        return rgba[:, :, :3]
+
     def set_fps(self, fps: float | None) -> None:
         """Update the FPS overlay in the top-left corner. Pass None to hide."""
         if fps is None:

--- a/wxmplot/image_canvas.py
+++ b/wxmplot/image_canvas.py
@@ -202,7 +202,9 @@ class ImageCanvas(wx.Panel):
         if image is None or image.size == 0:
             return
         self._pending_image = image
-        if not self._redraw_timer.IsRunning():
+        if self._auto_scale:
+            self._on_redraw_tick(None)
+        elif not self._redraw_timer.IsRunning():
             self._redraw_timer.StartOnce(self._redraw_interval_ms)
 
     def set_contrast(self, min_val: float, max_val: float) -> None:
@@ -334,7 +336,7 @@ class ImageCanvas(wx.Panel):
             gpu_image = np.ascontiguousarray(gpu_image)
 
         if self._auto_scale:
-            self._min_value, self._max_value = self._compute_auto_clim(gpu_image)
+            self._min_value, self._max_value = self._compute_auto_clim(full_res)
             self._data_min, self._data_max = self._min_value, self._max_value
             self._image_visual.clim = (self._min_value, self._max_value)
 
@@ -369,10 +371,19 @@ class ImageCanvas(wx.Panel):
                 k_lo = min(max(int(n * 0.01), 0), n - 1)
                 k_hi = min(max(int(n * 0.99), k_lo + 1), n - 1)
                 part = np.partition(nonzero, (k_lo, k_hi))
-                return float(part[k_lo]), float(part[k_hi])
-            if n > 0:
-                return float(nonzero.min()), float(nonzero.max())
-        return float(sample.min()), float(sample.max())
+                vmin, vmax = float(part[k_lo]), float(part[k_hi])
+            elif n > 0:
+                vmin, vmax = float(nonzero.min()), float(nonzero.max())
+            else:
+                vmin, vmax = 0.0, 1.0  # Fallback if all zeros
+        else:
+            vmin, vmax = float(sample.min()), float(sample.max())
+        
+        # Ensure min != max to avoid histogram handle overlap
+        if vmax <= vmin:
+            vmax = vmin + 1.0
+        
+        return vmin, vmax
 
     def _screen_to_image(self, sx: int, sy: int) -> tuple[float, float] | None:
         """Map a canvas screen position to image pixel coordinates, or None if no image is loaded."""

--- a/wxmplot/image_canvas.py
+++ b/wxmplot/image_canvas.py
@@ -167,7 +167,7 @@ class ImageCanvas(wx.Panel):
 
         self._pixel_info_text = scene.visuals.Text(
             text="",
-            color=self._theme_green(255),
+            color=vispy_colour("green"),
             font_size=6,
             bold=True,
             anchor_x="left",
@@ -302,7 +302,7 @@ class ImageCanvas(wx.Panel):
         self._canvas.bgcolor = tuple(c / 255 for c in get_color("bg"))
         self._roi_line.set_data(color=vispy_colour("plot_selection"))
         self._line_visual.set_data(color=self._theme_yellow(200))
-        self._pixel_info_text.color = self._theme_green(255)
+        self._pixel_info_text.color = vispy_colour("green")
         self._canvas.update()
 
     def _on_redraw_tick(self, _: wx.TimerEvent) -> None:

--- a/wxmplot/image_canvas.py
+++ b/wxmplot/image_canvas.py
@@ -1,0 +1,578 @@
+#!/usr/bin/python
+"""
+wxmplot ImageCanvas: a generic hardware-accelerated image viewer widget using VisPy
+with pan/zoom, ROI selection, line ROI, and pixel info overlay.
+"""
+
+import sys
+import time
+from enum import StrEnum
+from typing import Callable
+
+import numpy as np
+import vispy
+import wx
+
+vispy.use(app="wx", gl="glplus" if sys.platform == "win32" else "gl2")
+
+from vispy import scene  # noqa: E402
+
+from wxmplot.colors import lookup_colormap
+
+__all__ = ["ImageCanvas", "BinMethod"]
+
+
+class BinMethod(StrEnum):
+    """Live downsampling method for ImageCanvas."""
+
+    NONE = "none"
+    STRIDE = "stride"
+    MEAN = "mean"
+
+
+# Integer dtypes the GPU can sample natively via VisPy's Image visual.
+_GPU_NATIVE_INT_DTYPES = frozenset({np.uint8, np.uint16, np.uint32, np.int8, np.int16, np.int32})
+
+# Largest integer downsampling factor applied to a live frame.
+_MAX_LIVE_BIN = 4
+
+
+def _bin_stride(image: np.ndarray, n: int) -> np.ndarray:
+    """Zero-copy stride: image[::n, ::n]."""
+    if n <= 1:
+        return image
+    return image[::n, ::n]
+
+
+def _bin_mean(image: np.ndarray, n: int) -> np.ndarray:
+    """Block mean binning: reshape then average. Full downsampling."""
+    if n <= 1:
+        return image
+    h, w = image.shape[:2]
+    h2 = (h // n) * n
+    w2 = (w // n) * n
+    if h2 == 0 or w2 == 0:
+        return image
+    cropped = image[:h2, :w2]
+    if cropped.ndim == 2:
+        return cropped.reshape(h2 // n, n, w2 // n, n).mean(axis=(1, 3), dtype=np.float32).astype(image.dtype, copy=False)
+    c = cropped.shape[2]
+    return cropped.reshape(h2 // n, n, w2 // n, n, c).mean(axis=(1, 3), dtype=np.float32).astype(image.dtype, copy=False)
+
+
+def _bin_for_display(image: np.ndarray, n: int, method: BinMethod) -> np.ndarray:
+    """Downsample image by factor n using BinMethod."""
+    if n <= 1:
+        return image
+    if method == BinMethod.MEAN:
+        return _bin_mean(image, n)
+    return _bin_stride(image, n)
+
+
+class ImageCanvas(wx.Panel):
+    """Generic hardware-accelerated image viewer using VisPy."""
+
+    _AUTO_CLIM_SAMPLE_BUDGET = 256_000
+
+    def __init__(self, parent: wx.Window) -> None:
+        """Initializes the ImageCanvas."""
+        super().__init__(parent)
+
+        self._canvas = scene.SceneCanvas(
+            keys=None,
+            parent=self,
+            app="wx",
+            vsync=True,
+            size=(100, 100),
+            config={"samples": 0, "double_buffer": True, "depth_size": 0, "stencil_size": 0},
+        )
+        self._view = self._canvas.central_widget.add_view()
+        self._view.camera = scene.PanZoomCamera(aspect=1)
+        self._view.camera.flip = (0, 1, 0)
+        self._view.camera.interactive = False
+
+        self._image_visual = scene.visuals.Image(
+            np.zeros((512, 512), dtype=np.float32),
+            parent=self._view.scene,
+            cmap="grays",
+            clim="auto",
+        )
+
+        self._raw_image = None
+        self._colormap = "grays"
+        self._first_image = True
+        self._auto_scale = True
+        self._filter_gaps = False
+        self._min_value = 0.0
+        self._max_value = 255.0
+        self._data_min = 0.0
+        self._data_max = 255.0
+
+        self._pending_image = None
+        self._redraw_interval_ms = 16
+        self._redraw_timer = wx.Timer(self)
+        self.Bind(wx.EVT_TIMER, self._on_redraw_tick, self._redraw_timer)
+
+        self._bin_method = BinMethod.NONE
+
+        self._panning = False
+        self._last_mouse_pos = None
+
+        self._roi_selecting = False
+        self._roi_start = None
+        self._roi_img_coords = None
+        self._roi_dragging = False
+        self._roi_drag_start_img = None
+        self._roi_drag_orig_coords = None
+        self._on_roi_changed = None
+        self._on_roi_cleared = None
+
+        self._line_start_img = None
+        self._line_end_img = None
+        self._line_coords = None
+        self._on_line_changed = None
+
+        self._last_pixel_info_text = ""
+        self._last_pixel_info_time = 0.0
+        self._pixel_info_min_interval = 1.0 / 60.0
+
+        self._roi_line = scene.visuals.Line(
+            pos=np.array([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]], dtype=np.float32),
+            color=(99 / 255, 179 / 255, 237 / 255, 180 / 255),
+            width=2,
+            method="gl",
+            parent=self._view.scene,
+        )
+        self._roi_line.visible = False
+
+        self._line_visual = scene.visuals.Line(
+            pos=np.array([[0, 0], [1, 1]], dtype=np.float32),
+            color=(237 / 255, 179 / 255, 99 / 255, 200 / 255),
+            width=2,
+            method="gl",
+            parent=self._view.scene,
+        )
+        self._line_visual.visible = False
+
+        self._line_start_marker = scene.visuals.Markers(parent=self._view.scene)
+        self._line_start_marker.set_data(
+            pos=np.array([[0, 0, 0]], dtype=np.float32),
+            face_color=(0, 0, 0, 0),
+            edge_color=(0, 0, 0, 0),
+            size=1,
+        )
+        self._line_start_marker.visible = False
+
+        self._pixel_info_text = scene.visuals.Text(
+            text="",
+            color=(72 / 255, 199 / 255, 116 / 255, 1.0),
+            font_size=8,
+            bold=True,
+            anchor_x="left",
+            anchor_y="top",
+            parent=self._canvas.scene,
+        )
+        self._pixel_info_text.visible = False
+
+        sizer = wx.BoxSizer(wx.VERTICAL)
+        sizer.Add(self._canvas.native, 1, wx.EXPAND)
+        self.SetSizer(sizer)
+        self._canvas.show()
+
+        self._canvas.native.Bind(wx.EVT_MOUSEWHEEL, self._on_mouse_wheel)
+        self._canvas.native.Bind(wx.EVT_LEFT_DOWN, self._on_left_down)
+        self._canvas.native.Bind(wx.EVT_LEFT_UP, self._on_left_up)
+        self._canvas.native.Bind(wx.EVT_MOTION, self._on_mouse_move)
+        self._canvas.native.Bind(wx.EVT_RIGHT_DCLICK, self._on_right_dclick)
+
+    def set_colormap(self, colormap: str) -> None:
+        """Set the colormap by name."""
+        self._colormap = colormap
+        self._image_visual.cmap = lookup_colormap(colormap)
+        self._canvas.update()
+
+    def set_image(self, image: np.ndarray) -> None:
+        """Stash the latest frame and pass it to the redraw timer."""
+        if image is None or image.size == 0:
+            return
+        self._pending_image = image
+        if not self._redraw_timer.IsRunning():
+            self._redraw_timer.StartOnce(self._redraw_interval_ms)
+
+    def set_contrast(self, min_val: float, max_val: float) -> None:
+        """Set contrast limits and disable auto-scaling."""
+        self._auto_scale = False
+        self._min_value = min_val
+        self._max_value = max_val
+        self._image_visual.clim = (min_val, max_val)
+        self._canvas.update()
+
+    def set_auto_scale(self, enabled: bool) -> None:
+        """Enable or disable automatic contrast scaling."""
+        self._auto_scale = enabled
+        if enabled and self._raw_image is not None:
+            self._min_value, self._max_value = self._compute_auto_clim(self._raw_image)
+            self._image_visual.clim = (self._min_value, self._max_value)
+            self._canvas.update()
+
+    def set_filter_gaps(self, enabled: bool) -> None:
+        """Enable or disable zero-pixel filtering."""
+        self._filter_gaps = enabled
+        if self._auto_scale and self._raw_image is not None:
+            self.set_auto_scale(True)
+
+    def set_bin_method(self, method: BinMethod) -> None:
+        """Switch the live downsampling method; must be a BinMethod value."""
+        if not isinstance(method, BinMethod):
+            raise ValueError(f"Unknown bin method: {method!r}; expected a BinMethod value")
+        self._bin_method = method
+        if self._raw_image is not None:
+            self._apply_image(self._raw_image)
+
+    def reset_view(self) -> None:
+        """Reset pan/zoom to fit the image and clear any active ROI."""
+        if self._raw_image is not None:
+            h, w = self._raw_image.shape[:2]
+            self._view.camera.set_range(x=(0, w), y=(0, h))
+        self._roi_img_coords = None
+        self._roi_line.visible = False
+        self._hide_line_visual()
+        self._canvas.update()
+
+    def get_roi_coords(self) -> tuple[int, int, int, int] | None:
+        """Return the current ROI as (x1, y1, x2, y2) in image pixels, or None."""
+        return self._roi_img_coords
+
+    def get_line_coords(self) -> tuple[int, int, int, int] | None:
+        """Return the current line ROI as (x1, y1, x2, y2) in image pixels, or None."""
+        return self._line_coords
+
+    def get_data_range(self) -> tuple[float, float]:
+        """Return the (min, max) of the last auto-scaled frame."""
+        return self._data_min, self._data_max
+
+    def get_contrast_range(self) -> tuple[float, float]:
+        """Return the current contrast (min, max) limits."""
+        return self._min_value, self._max_value
+
+    def format_pixel_info(self, ix: int, iy: int, intensity: float) -> str:
+        """Return the pixel info string shown in the overlay. Override in a subclass to append specific fields."""
+        return f"x: {ix}  y: {iy}  I: {intensity:.4g}"
+
+    @property
+    def bin_method(self) -> str:
+        """Current live downsampling method."""
+        return self._bin_method
+
+    @property
+    def native(self) -> wx.Window:
+        """The VisPy native wx.Window."""
+        return self._canvas.native
+
+    def set_roi_changed_callback(self, callback: Callable) -> None:
+        """Register a callback with (x1, y1, x2, y2) when the ROI changes."""
+        self._on_roi_changed = callback
+
+    def set_roi_cleared_callback(self, callback: Callable) -> None:
+        """Register a callback when the ROI is cleared."""
+        self._on_roi_cleared = callback
+
+    def set_line_changed_callback(self, callback: Callable) -> None:
+        """Register a callback with (x1, y1, x2, y2) when the line ROI changes."""
+        self._on_line_changed = callback
+
+    def _on_redraw_tick(self, _: wx.TimerEvent) -> None:
+        """Apply the latest pending frame and re-arm the timer if more arrived."""
+        image = self._pending_image
+        self._pending_image = None
+        if image is not None:
+            self._apply_image(image)
+        if self._pending_image is not None:
+            self._redraw_timer.StartOnce(self._redraw_interval_ms)
+
+    def _apply_image(self, image: np.ndarray) -> None:
+        """Sanitize, bin, and upload image to the GPU. Auto-scale if enabled."""
+        is_rgb = image.ndim == 3 and image.shape[2] in (3, 4)
+        if is_rgb and image.shape[2] == 4:
+            image = image[:, :, :3]
+
+        if image.dtype.type in _GPU_NATIVE_INT_DTYPES:
+            full_res = image if image.flags.c_contiguous else np.ascontiguousarray(image)
+        else:
+            full_res = np.nan_to_num(image.astype(np.float32, copy=False), nan=0.0, posinf=0.0, neginf=0.0, copy=False)
+        self._raw_image = full_res
+
+        bin_factor = self._pick_live_bin_factor(full_res.shape[:2])
+        gpu_image = _bin_for_display(full_res, bin_factor, self._bin_method)
+        if not gpu_image.flags.c_contiguous:
+            gpu_image = np.ascontiguousarray(gpu_image)
+
+        if self._auto_scale:
+            self._min_value, self._max_value = self._compute_auto_clim(gpu_image)
+            self._data_min, self._data_max = self._min_value, self._max_value
+            self._image_visual.clim = (self._min_value, self._max_value)
+
+        self._image_visual.set_data(gpu_image)
+        if self._first_image:
+            self.reset_view()
+            self._first_image = False
+        self._canvas.update()
+
+    def _pick_live_bin_factor(self, image_hw: tuple[int, int]) -> int:
+        """Return the smallest integer bin factor that keeps the image larger than the canvas."""
+        if self._bin_method == BinMethod.NONE:
+            return 1
+        cw, ch = self._canvas.size
+        if cw <= 0 or ch <= 0:
+            return 1
+        ih, iw = image_hw
+        ratio = max(iw / cw, ih / ch)
+        if ratio <= 1.0:
+            return 1
+        return min(_MAX_LIVE_BIN, int(ratio))
+
+    def _compute_auto_clim(self, img: np.ndarray) -> tuple[float, float]:
+        """Estimate display clim from a sampled subset of pixels. Uses percentiles when filter_gaps is on."""
+        flat = img.reshape(-1)
+        step = max(1, flat.size // self._AUTO_CLIM_SAMPLE_BUDGET)
+        sample = flat[::step]
+        if self._filter_gaps:
+            nonzero = sample[sample > 0]
+            n = nonzero.size
+            if n >= 3:
+                k_lo = min(max(int(n * 0.01), 0), n - 1)
+                k_hi = min(max(int(n * 0.99), k_lo + 1), n - 1)
+                part = np.partition(nonzero, (k_lo, k_hi))
+                return float(part[k_lo]), float(part[k_hi])
+            if n > 0:
+                return float(nonzero.min()), float(nonzero.max())
+        return float(sample.min()), float(sample.max())
+
+    def _screen_to_image(self, sx: int, sy: int) -> tuple[float, float] | None:
+        """Map a canvas screen position to image pixel coordinates, or None if no image is loaded."""
+        if self._raw_image is None:
+            return None
+        tr = self._image_visual.transforms.get_transform("canvas", "visual")
+        img_pos = tr.map((sx, sy))
+        return float(img_pos[0]), float(img_pos[1])
+
+    def _is_inside_roi(self, ix: float, iy: float) -> bool:
+        """Return True if the image coordinate falls within the current ROI bounds."""
+        if self._roi_img_coords is None:
+            return False
+        x1, y1, x2, y2 = self._roi_img_coords
+        return x1 <= ix <= x2 and y1 <= iy <= y2
+
+    def _set_roi_visual(self, x1: float, y1: float, x2: float, y2: float) -> None:
+        """Update and show the ROI rectangle visual."""
+        pts = np.array([[x1, y1], [x2, y1], [x2, y2], [x1, y2], [x1, y1]], dtype=np.float32)
+        self._roi_line.set_data(pos=pts)
+        self._roi_line.visible = True
+        self._canvas.update()
+
+    def _set_line_visual(self, x1: float, y1: float, x2: float, y2: float) -> None:
+        """Update and show the line ROI visual."""
+        self._line_visual.set_data(pos=np.array([[x1, y1], [x2, y2]], dtype=np.float32))
+        self._line_visual.visible = True
+        self._canvas.update()
+
+    def _set_line_start_marker(self, x: float, y: float) -> None:
+        """Place and show the line start marker at the given image coordinate."""
+        self._line_start_marker.set_data(
+            pos=np.array([[x, y, 0]], dtype=np.float32),
+            face_color=(237 / 255, 179 / 255, 99 / 255, 1.0),
+            edge_color=(237 / 255, 179 / 255, 99 / 255, 1.0),
+            size=8,
+        )
+        self._line_start_marker.visible = True
+        self._canvas.update()
+
+    def _hide_line_visual(self) -> None:
+        """Hide the line ROI visual and clear all line state."""
+        self._line_visual.visible = False
+        self._line_start_marker.visible = False
+        self._line_start_img = None
+        self._line_end_img = None
+        self._line_coords = None
+
+    def _update_pixel_info(self, sx: int, sy: int) -> None:
+        """Update the pixel info overlay text for the given screen position, rate-limited to 60 Hz."""
+        now = time.perf_counter()
+        if now - self._last_pixel_info_time < self._pixel_info_min_interval:
+            return
+        self._last_pixel_info_time = now
+        img_pos = self._screen_to_image(sx, sy)
+        if img_pos is None or self._raw_image is None:
+            if self._pixel_info_text.visible:
+                self._pixel_info_text.visible = False
+                self._last_pixel_info_text = ""
+                self._canvas.update()
+            return
+        ix, iy = int(img_pos[0]), int(img_pos[1])
+        h, w = self._raw_image.shape[:2]
+        if 0 <= ix < w and 0 <= iy < h:
+            pixel = self._raw_image[iy, ix]
+            _, canvas_h = self._canvas.size
+            intensity = float(np.mean(pixel)) if self._raw_image.ndim == 3 else float(pixel)
+            text = self.format_pixel_info(ix, iy, intensity)
+            if text != self._last_pixel_info_text:
+                self._pixel_info_text.text = text
+                self._pixel_info_text.pos = (8, canvas_h - 20)
+                self._pixel_info_text.visible = True
+                self._last_pixel_info_text = text
+                self._canvas.update()
+        elif self._pixel_info_text.visible:
+            self._pixel_info_text.visible = False
+            self._last_pixel_info_text = ""
+            self._canvas.update()
+
+    def _on_mouse_wheel(self, event: wx.MouseEvent) -> None:
+        """Zoom around the cursor position on mouse wheel."""
+        if event.GetWheelRotation() == 0:
+            return
+        zoom = 1.1 ** (-event.GetWheelRotation() / 120.0)
+        before = self._screen_to_image(event.GetX(), event.GetY())
+        self._view.camera.zoom(zoom)
+        if before is not None:
+            after = self._screen_to_image(event.GetX(), event.GetY())
+            if after is not None:
+                self._view.camera.pan((before[0] - after[0], before[1] - after[1]))
+        self._canvas.update()
+
+    def _on_left_down(self, event: wx.MouseEvent) -> None:
+        """Handle pan (plain click), line ROI (alt), and ROI selection or drag (ctrl)."""
+        if event.AltDown():
+            img_pos = self._screen_to_image(event.GetX(), event.GetY())
+            if img_pos is not None:
+                if self._line_start_img is None:
+                    self._line_start_img = img_pos
+                    self._roi_line.visible = False
+                    self._roi_img_coords = None
+                    self._set_line_start_marker(*img_pos)
+                else:
+                    x1, y1 = int(round(self._line_start_img[0])), int(round(self._line_start_img[1]))
+                    x2, y2 = int(round(img_pos[0])), int(round(img_pos[1]))
+                    self._line_start_img = None
+                    self._line_end_img = img_pos
+                    self._line_coords = (x1, y1, x2, y2)
+                    self._line_start_marker.visible = False
+                    self._set_line_visual(x1, y1, x2, y2)
+                    if self._on_line_changed:
+                        self._on_line_changed(x1, y1, x2, y2)
+        elif event.ControlDown():
+            self._line_start_img = None
+            self._line_end_img = None
+            self._line_coords = None
+            self._hide_line_visual()
+            img_pos = self._screen_to_image(event.GetX(), event.GetY())
+            if img_pos is not None and self._is_inside_roi(*img_pos):
+                self._roi_dragging = True
+                self._roi_drag_start_img = img_pos
+                self._roi_drag_orig_coords = self._roi_img_coords
+            else:
+                self._roi_selecting = True
+                self._roi_start = (event.GetX(), event.GetY())
+                self._roi_img_coords = None
+                self._roi_line.visible = False
+                self._canvas.update()
+        else:
+            self._panning = True
+            self._last_mouse_pos = (event.GetX(), event.GetY())
+        event.Skip()
+
+    def _on_left_up(self, event: wx.MouseEvent) -> None:
+        """Finalise pan, ROI drag, or ROI selection on mouse release."""
+        if self._roi_dragging:
+            self._roi_dragging = False
+            self._roi_drag_start_img = None
+            self._roi_drag_orig_coords = None
+            if self._on_roi_changed and self._roi_img_coords is not None:
+                self._on_roi_changed(*self._roi_img_coords)
+            self._canvas.update()
+            event.Skip()
+            return
+
+        if self._roi_selecting and self._roi_start is not None:
+            start_img = self._screen_to_image(*self._roi_start)
+            end_img = self._screen_to_image(event.GetX(), event.GetY())
+            if start_img is not None and end_img is not None:
+                x1 = int(min(start_img[0], end_img[0]))
+                y1 = int(min(start_img[1], end_img[1]))
+                x2 = int(max(start_img[0], end_img[0]))
+                y2 = int(max(start_img[1], end_img[1]))
+                if x2 > x1 and y2 > y1:
+                    self._roi_img_coords = (x1, y1, x2, y2)
+                    self._set_roi_visual(x1, y1, x2, y2)
+                    if self._on_roi_changed:
+                        self._on_roi_changed(x1, y1, x2, y2)
+                else:
+                    self._roi_line.visible = False
+            else:
+                self._roi_line.visible = False
+
+        self._roi_selecting = False
+        self._roi_start = None
+        self._panning = False
+        self._last_mouse_pos = None
+        self._canvas.update()
+        event.Skip()
+
+    def _on_mouse_move(self, event: wx.MouseEvent) -> None:
+        """Drive pan, ROI drag, ROI rubber-band, line preview, and pixel info on mouse move."""
+        if self._panning and self._last_mouse_pos:
+            dx = event.GetX() - self._last_mouse_pos[0]
+            dy = event.GetY() - self._last_mouse_pos[1]
+            self._view.camera.pan((-dx, -dy))
+            self._canvas.update()
+            self._last_mouse_pos = (event.GetX(), event.GetY())
+        elif self._roi_dragging and self._roi_drag_start_img is not None:
+            cur = self._screen_to_image(event.GetX(), event.GetY())
+            if cur is not None and self._roi_drag_orig_coords is not None:
+                dx = cur[0] - self._roi_drag_start_img[0]
+                dy = cur[1] - self._roi_drag_start_img[1]
+                ox1, oy1, ox2, oy2 = self._roi_drag_orig_coords
+                if self._raw_image is not None:
+                    h, w = self._raw_image.shape[:2]
+                    rw, rh = ox2 - ox1, oy2 - oy1
+                    nx1 = max(0, min(int(ox1 + dx), w - rw))
+                    ny1 = max(0, min(int(oy1 + dy), h - rh))
+                    nx2, ny2 = nx1 + rw, ny1 + rh
+                else:
+                    nx1, ny1 = int(ox1 + dx), int(oy1 + dy)
+                    nx2, ny2 = int(ox2 + dx), int(oy2 + dy)
+                self._roi_img_coords = (nx1, ny1, nx2, ny2)
+                self._set_roi_visual(nx1, ny1, nx2, ny2)
+        elif self._roi_selecting and self._roi_start is not None:
+            start_img = self._screen_to_image(*self._roi_start)
+            end_img = self._screen_to_image(event.GetX(), event.GetY())
+            if start_img is not None and end_img is not None:
+                x1 = min(start_img[0], end_img[0])
+                y1 = min(start_img[1], end_img[1])
+                x2 = max(start_img[0], end_img[0])
+                y2 = max(start_img[1], end_img[1])
+                if x2 > x1 and y2 > y1:
+                    self._set_roi_visual(x1, y1, x2, y2)
+        elif self._line_start_img is not None and event.AltDown():
+            img_pos = self._screen_to_image(event.GetX(), event.GetY())
+            if img_pos is not None:
+                self._set_line_visual(self._line_start_img[0], self._line_start_img[1], img_pos[0], img_pos[1])
+        else:
+            img_pos = self._screen_to_image(event.GetX(), event.GetY())
+            cursor = wx.CURSOR_SIZING if (img_pos is not None and self._is_inside_roi(*img_pos)) else wx.CURSOR_DEFAULT
+            self._canvas.native.SetCursor(wx.Cursor(cursor))
+
+        self._update_pixel_info(event.GetX(), event.GetY())
+        event.Skip()
+
+    def _on_right_dclick(self, event: wx.MouseEvent) -> None:
+        """Reset view and clear ROI on right double-click."""
+        if self._raw_image is not None:
+            h, w = self._raw_image.shape[:2]
+            self._view.camera.set_range(x=(0, w), y=(0, h))
+        self._roi_img_coords = None
+        self._roi_line.visible = False
+        self._hide_line_visual()
+        self._canvas.update()
+        if self._on_roi_cleared:
+            self._on_roi_cleared()
+        event.Skip()

--- a/wxmplot/image_canvas.py
+++ b/wxmplot/image_canvas.py
@@ -186,6 +186,8 @@ class ImageCanvas(wx.Panel):
         self._canvas.native.Bind(wx.EVT_MOUSEWHEEL, self._on_mouse_wheel)
         self._canvas.native.Bind(wx.EVT_LEFT_DOWN, self._on_left_down)
         self._canvas.native.Bind(wx.EVT_LEFT_UP, self._on_left_up)
+        self._canvas.native.Bind(wx.EVT_RIGHT_DOWN, self._on_right_down)
+        self._canvas.native.Bind(wx.EVT_RIGHT_UP, self._on_right_up)
         self._canvas.native.Bind(wx.EVT_MOTION, self._on_mouse_move)
         self._canvas.native.Bind(wx.EVT_RIGHT_DCLICK, self._on_right_dclick)
 
@@ -465,7 +467,7 @@ class ImageCanvas(wx.Panel):
         self._canvas.update()
 
     def _on_left_down(self, event: wx.MouseEvent) -> None:
-        """Handle pan (plain click), line ROI (alt), and ROI selection or drag (ctrl)."""
+        """Handle line ROI (alt+click) and ROI selection or drag (plain left drag)."""
         if event.AltDown():
             img_pos = self._screen_to_image(event.GetX(), event.GetY())
             if img_pos is not None:
@@ -484,7 +486,7 @@ class ImageCanvas(wx.Panel):
                     self._set_line_visual(x1, y1, x2, y2)
                     if self._on_line_changed:
                         self._on_line_changed(x1, y1, x2, y2)
-        elif event.ControlDown():
+        else:
             self._line_start_img = None
             self._line_end_img = None
             self._line_coords = None
@@ -500,13 +502,22 @@ class ImageCanvas(wx.Panel):
                 self._roi_img_coords = None
                 self._roi_line.visible = False
                 self._canvas.update()
-        else:
-            self._panning = True
-            self._last_mouse_pos = (event.GetX(), event.GetY())
+        event.Skip()
+
+    def _on_right_down(self, event: wx.MouseEvent) -> None:
+        """Start pan on right down."""
+        self._panning = True
+        self._last_mouse_pos = (event.GetX(), event.GetY())
+        event.Skip()
+
+    def _on_right_up(self, event: wx.MouseEvent) -> None:
+        """End pan on right up."""
+        self._panning = False
+        self._last_mouse_pos = None
         event.Skip()
 
     def _on_left_up(self, event: wx.MouseEvent) -> None:
-        """Finalise pan, ROI drag, or ROI selection on mouse release."""
+        """Finalise ROI drag or ROI selection on mouse release."""
         if self._roi_dragging:
             self._roi_dragging = False
             self._roi_drag_start_img = None
@@ -537,8 +548,6 @@ class ImageCanvas(wx.Panel):
 
         self._roi_selecting = False
         self._roi_start = None
-        self._panning = False
-        self._last_mouse_pos = None
         self._canvas.update()
         event.Skip()
 

--- a/wxmplot/line_plot.py
+++ b/wxmplot/line_plot.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-wxmplot ImageCanvas: a generic 1D line plot widget with pan/zoom, fill area, zoom, and
+wxmplot LinePlot: a generic 1D line plot widget with pan/zoom, fill area, zoom, and
 hover overlay.  Axes, tick labels, and overlays are painted with wx.GraphicsContext
 on the outer wx.Panel and the curve and fill are rendered by a VisPy SceneCanvas
 embedded inside the plot margins.

--- a/wxmplot/line_plot.py
+++ b/wxmplot/line_plot.py
@@ -1,0 +1,570 @@
+#!/usr/bin/python
+"""
+wxmplot ImageCanvas: a generic 1D line plot widget with pan/zoom, fill area, zoom, and
+hover overlay.  Axes, tick labels, and overlays are painted with wx.GraphicsContext
+on the outer wx.Panel and the curve and fill are rendered by a VisPy SceneCanvas
+embedded inside the plot margins.
+"""
+
+import math
+from typing import Callable
+
+import numpy as np
+import wx
+from wxutils.colors import get_color, is_dark_theme, register_darkdetect
+
+from wxmplot.vispy_utils import vispy_colour, vispy_init, vsync_for_platform
+
+vispy_init()
+
+from vispy import scene  # noqa: E402
+
+__all__ = ["LinePlot"]
+
+
+class LinePlot(wx.Panel):
+    """Generic 1D line plot with VisPy curve rendering and wx.GC axes."""
+
+    def __init__(
+        self,
+        parent: wx.Window,
+        margin_left: int = 82,
+        margin_right: int = 14,
+        margin_top: int = 30,
+        margin_bottom: int = 50,
+    ) -> None:
+        """Initialise the LinePlot panel."""
+        super().__init__(parent)
+        self.SetMinSize((-1, 160))
+        self.SetBackgroundStyle(wx.BG_STYLE_PAINT)
+
+        self._ml = margin_left
+        self._mr = margin_right
+        self._mt = margin_top
+        self._mb = margin_bottom
+
+        self._xs: np.ndarray | None = None
+        self._ys: np.ndarray | None = None
+        self._x_label: str = "x"
+        self._y_label: str = "y"
+
+        self._hover_data_x: float | None = None
+        self._hover_data_y: float | None = None
+
+        self._zoom_x_min: float | None = None
+        self._zoom_x_max: float | None = None
+        self._zoom_y_min: float | None = None
+        self._zoom_y_max: float | None = None
+        self._panning: bool = False
+        self._pan_last_pt: wx.Point | None = None
+        self._drag_start: wx.Point | None = None
+        self._drag_end: wx.Point | None = None
+
+        self._data_changed_cb: Callable[[np.ndarray, np.ndarray], None] | None = None
+
+        self._canvas = scene.SceneCanvas(
+            keys=None,
+            parent=self,
+            app="wx",
+            vsync=vsync_for_platform(),
+            size=(100, 100),
+            bgcolor=vispy_colour("bg"),
+            config={"double_buffer": True, "depth_size": 0, "stencil_size": 0},
+        )
+        self._view = self._canvas.central_widget.add_view()
+        self._view.camera = scene.PanZoomCamera(aspect=None)
+        self._view.camera.interactive = False
+
+        self._curve_line = scene.visuals.Line(
+            pos=np.array([[0, 0], [1, 1]], dtype=np.float32),
+            color=vispy_colour("plot_curve"),
+            width=1.5,
+            method="agg",
+            parent=self._view.scene,
+        )
+        self._curve_line.visible = False
+
+        self._fill_mesh = scene.visuals.Mesh(
+            vertices=np.zeros((4, 2), dtype=np.float32),
+            faces=np.array([[0, 1, 2], [0, 2, 3]], dtype=np.uint32),
+            color=vispy_colour("plot_fill"),
+            parent=self._view.scene,
+        )
+        self._fill_mesh.visible = False
+
+        self._sel_line = scene.visuals.Line(
+            pos=np.array([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]], dtype=np.float32),
+            color=vispy_colour("plot_selection"),
+            width=1,
+            method="agg",
+            connect="strip",
+            parent=self._view.scene,
+        )
+        self._sel_line.visible = False
+
+        self._canvas.native.Hide()
+
+        register_darkdetect(self._on_theme_change)
+
+        self.Bind(wx.EVT_PAINT, self._on_paint)
+        self.Bind(wx.EVT_SIZE, self._on_size)
+        self.Bind(wx.EVT_MOTION, self._on_mouse_move)
+        self.Bind(wx.EVT_LEAVE_WINDOW, self._on_leave)
+        self.Bind(wx.EVT_LEFT_DOWN, self._on_mouse_down)
+        self.Bind(wx.EVT_LEFT_UP, self._on_mouse_up)
+        self.Bind(wx.EVT_MOUSEWHEEL, self._on_mouse_wheel)
+        self.Bind(wx.EVT_RIGHT_DCLICK, self._on_right_dclick)
+
+        self._canvas.native.Bind(wx.EVT_MOUSEWHEEL, self._on_mouse_wheel)
+        self._canvas.native.Bind(wx.EVT_LEFT_DOWN, self._on_mouse_down)
+        self._canvas.native.Bind(wx.EVT_LEFT_UP, self._on_mouse_up)
+        self._canvas.native.Bind(wx.EVT_MOTION, self._on_canvas_mouse_move)
+        self._canvas.native.Bind(wx.EVT_LEAVE_WINDOW, self._on_canvas_leave)
+        self._canvas.native.Bind(wx.EVT_RIGHT_DCLICK, self._on_right_dclick)
+
+        wx.CallAfter(self._reposition_canvas)
+
+    def set_data(self, xs: np.ndarray, ys: np.ndarray, x_label: str = "x", y_label: str = "y") -> None:
+        """Set the curve data and reset zoom."""
+        self._xs = xs
+        self._ys = ys
+        self._x_label = x_label
+        self._y_label = y_label
+        self._zoom_x_min = self._zoom_x_max = self._zoom_y_min = self._zoom_y_max = None
+        self._rebuild_visuals()
+        self.Refresh()
+        if self._data_changed_cb is not None:
+            self._data_changed_cb(xs, ys)
+
+    def clear(self) -> None:
+        """Clear all data and reset the plot."""
+        self._xs = None
+        self._ys = None
+        self._x_label = "x"
+        self._y_label = "y"
+        self._zoom_x_min = self._zoom_x_max = self._zoom_y_min = self._zoom_y_max = None
+        self._rebuild_visuals()
+        self.Refresh()
+
+    def reset_view(self) -> None:
+        """Reset zoom to show the full data range."""
+        self._zoom_x_min = self._zoom_x_max = self._zoom_y_min = self._zoom_y_max = None
+        if self._xs is not None:
+            self._sync_camera()
+        self.Refresh()
+
+    def set_data_changed_callback(self, callback: Callable[[np.ndarray, np.ndarray], None]) -> None:
+        """Register a callback fired with (xs, ys) whenever new data is set."""
+        self._data_changed_cb = callback
+
+    def format_hover_info(self, x: float, y: float) -> str:
+        """Return the hover overlay string. Override in a subclass to add domain fields."""
+        return f"{self._x_label}: {x:.4g}   {self._y_label}: {y:.4g}"
+
+    def draw_overlays(self, gc: wx.GraphicsContext, W: int, H: int) -> None:
+        """Hook for subclasses to paint additional overlays after axes are drawn."""
+
+    @property
+    def xs(self) -> np.ndarray | None:
+        """Current x data array."""
+        return self._xs
+
+    @property
+    def ys(self) -> np.ndarray | None:
+        """Current y data array."""
+        return self._ys
+
+    def _on_theme_change(self, is_dark: bool = False) -> None:
+        """Update VisPy visual colours and background when the system theme changes."""
+        self._canvas.bgcolor = vispy_colour("bg")
+        self._curve_line.set_data(color=vispy_colour("plot_curve"))
+        self._fill_mesh.color = vispy_colour("plot_fill")
+        self._sel_line.set_data(color=vispy_colour("plot_selection"))
+        self._canvas.update()
+        self.Refresh()
+
+    def _reposition_canvas(self) -> None:
+        """Reposition the embedded VisPy canvas inside the plot margins."""
+        W, H = self.GetSize()
+        pw = W - self._ml - self._mr
+        ph = H - self._mt - self._mb
+        self._canvas.native.SetPosition((self._ml, self._mt))
+        self._canvas.native.SetSize((max(1, pw), max(1, ph)))
+        self._canvas.native.Lower()
+
+    def _data_ranges(self) -> tuple[float, float, float, float] | None:
+        """Return (x_min, x_max, y_min, y_max) from current zoom or full data."""
+        if self._xs is None or self._ys is None or len(self._xs) < 2:
+            return None
+        x_min = self._zoom_x_min if self._zoom_x_min is not None else float(self._xs[0])
+        x_max = self._zoom_x_max if self._zoom_x_max is not None else float(self._xs[-1])
+        y_min = self._zoom_y_min if self._zoom_y_min is not None else float(self._ys.min())
+        y_max = self._zoom_y_max if self._zoom_y_max is not None else float(self._ys.max())
+        if x_max == x_min:
+            x_max = x_min + 1
+        if y_max == y_min:
+            y_max = y_min + 1
+        return x_min, x_max, y_min, y_max
+
+    def _rebuild_visuals(self) -> None:
+        """Rebuild the VisPy curve, fill mesh, and camera from current data."""
+        ranges = self._data_ranges()
+        has_data = ranges is not None and self._xs is not None and self._ys is not None
+
+        self._curve_line.visible = has_data
+        self._fill_mesh.visible = has_data
+        self._canvas.native.Show(has_data)
+
+        if not has_data:
+            self._canvas.update()
+            return
+
+        xs, ys = self._xs, self._ys
+        x_min, x_max, y_min, y_max = ranges
+
+        pts = np.column_stack([xs, ys]).astype(np.float32)
+        self._curve_line.set_data(pos=pts)
+
+        n = len(xs)
+        verts = np.empty((2 * n, 2), dtype=np.float32)
+        verts[:n, 0] = xs
+        verts[:n, 1] = ys
+        verts[n:, 0] = xs
+        verts[n:, 1] = y_min
+        faces = np.empty((2 * (n - 1), 3), dtype=np.uint32)
+        for i in range(n - 1):
+            faces[2 * i] = [i, i + 1, n + i]
+            faces[2 * i + 1] = [i + 1, n + i + 1, n + i]
+        self._fill_mesh.set_data(vertices=verts, faces=faces, color=vispy_colour("plot_fill"))
+
+        self._sync_camera()
+
+    def _sync_camera(self) -> None:
+        """Sync the VisPy camera to the current data ranges."""
+        ranges = self._data_ranges()
+        if ranges is None:
+            return
+        x_min, x_max, y_min, y_max = ranges
+        self._view.camera.set_range(x=(x_min, x_max), y=(y_min, y_max), margin=0)
+        self._canvas.update()
+
+    def _canvas_pt_to_panel(self, cx: int, cy: int) -> wx.Point:
+        """Translate a canvas-local coordinate to panel coordinates."""
+        return wx.Point(cx + self._ml, cy + self._mt)
+
+    def _panel_pt_in_plot(self, pt: wx.Point) -> bool:
+        """Return True if pt falls within the plot area."""
+        W, H = self.GetSize()
+        return self._ml <= pt.x <= W - self._mr and self._mt <= pt.y <= H - self._mb
+
+    def _panel_pt_to_data(self, pt: wx.Point) -> tuple[float, float] | None:
+        """Map a panel coordinate to data coordinates."""
+        ranges = self._data_ranges()
+        if ranges is None:
+            return None
+        W, H = self.GetSize()
+        pw = W - self._ml - self._mr
+        ph = H - self._mt - self._mb
+        if pw <= 0 or ph <= 0:
+            return None
+        x_min, x_max, y_min, y_max = ranges
+        dx = x_min + (pt.x - self._ml) / pw * (x_max - x_min)
+        dy = y_max - (pt.y - self._mt) / ph * (y_max - y_min)
+        return dx, dy
+
+    def _update_sel_box(self) -> None:
+        """Update the rubber-band selection rectangle visual."""
+        if self._drag_start is None or self._drag_end is None:
+            self._sel_line.visible = False
+            self._canvas.update()
+            return
+        ranges = self._data_ranges()
+        if ranges is None:
+            self._sel_line.visible = False
+            self._canvas.update()
+            return
+        W, H = self.GetSize()
+        pw = W - self._ml - self._mr
+        ph = H - self._mt - self._mb
+        x_min, x_max, y_min, y_max = ranges
+
+        s, e = self._drag_start, self._drag_end
+        cx0 = max(0, min(pw, s.x - self._ml))
+        cx1 = max(0, min(pw, e.x - self._ml))
+        cy0 = max(0, min(ph, s.y - self._mt))
+        cy1 = max(0, min(ph, e.y - self._mt))
+        sx = sorted([cx0, cx1])
+        sy = sorted([cy0, cy1])
+        if sx[1] - sx[0] <= 1 or sy[1] - sy[0] <= 1:
+            self._sel_line.visible = False
+            self._canvas.update()
+            return
+        dx0 = x_min + sx[0] / pw * (x_max - x_min)
+        dx1 = x_min + sx[1] / pw * (x_max - x_min)
+        dy0 = y_max - sy[1] / ph * (y_max - y_min)
+        dy1 = y_max - sy[0] / ph * (y_max - y_min)
+        pos = np.array([[dx0, dy0], [dx1, dy0], [dx1, dy1], [dx0, dy1], [dx0, dy0]], dtype=np.float32)
+        self._sel_line.set_data(pos=pos)
+        self._sel_line.visible = True
+        self._canvas.update()
+
+    def _clear_hover_state(self) -> None:
+        """Clear all hover, pan, and drag state."""
+        changed = self._hover_data_x is not None
+        self._hover_data_x = None
+        self._hover_data_y = None
+        self._panning = False
+        self._pan_last_pt = None
+        self._drag_start = None
+        self._drag_end = None
+        self._sel_line.visible = False
+        self._canvas.update()
+        if changed:
+            self.Refresh()
+
+    def _handle_mouse_move(self, pt: wx.Point, event: wx.MouseEvent) -> None:
+        """Handle shared mouse-move logic for both panel and canvas events."""
+        W, H = self.GetSize()
+
+        if self._drag_start is not None:
+            self._drag_end = pt
+            self._update_sel_box()
+            self.Refresh()
+            event.Skip()
+            return
+
+        if self._panning and self._pan_last_pt is not None:
+            ranges = self._data_ranges()
+            if ranges is not None:
+                pw = W - self._ml - self._mr
+                ph = H - self._mt - self._mb
+                x_min, x_max, y_min, y_max = ranges
+                dx = (pt.x - self._pan_last_pt.x) / pw * (x_max - x_min)
+                dy = (pt.y - self._pan_last_pt.y) / ph * (y_max - y_min)
+                self._zoom_x_min = x_min - dx
+                self._zoom_x_max = x_max - dx
+                self._zoom_y_min = y_min + dy
+                self._zoom_y_max = y_max + dy
+                self._pan_last_pt = pt
+                self._sync_camera()
+                self.Refresh()
+            event.Skip()
+            return
+
+        ranges = self._data_ranges()
+        pw = W - self._ml - self._mr
+        ph = H - self._mt - self._mb
+        if ranges is not None and self._ml <= pt.x <= self._ml + pw and self._mt <= pt.y <= self._mt + ph:
+            x_min, x_max, y_min, y_max = ranges
+            new_x = x_min + (pt.x - self._ml) / pw * (x_max - x_min)
+            new_y = y_max - (pt.y - self._mt) / ph * (y_max - y_min)
+        else:
+            new_x, new_y = None, None
+
+        if new_x != self._hover_data_x or new_y != self._hover_data_y:
+            self._hover_data_x = new_x
+            self._hover_data_y = new_y
+            self.Refresh()
+        event.Skip()
+
+    def _on_mouse_wheel(self, event: wx.MouseEvent) -> None:
+        """Zoom around the cursor position on mouse wheel."""
+        if self._xs is None or len(self._xs) < 2:
+            event.Skip()
+            return
+        W, H = self.GetSize()
+        pw, ph = W - self._ml - self._mr, H - self._mt - self._mb
+        raw_pt = event.GetPosition()
+        obj = event.GetEventObject()
+        pt = self._canvas_pt_to_panel(raw_pt.x, raw_pt.y) if obj is self._canvas.native else raw_pt
+        if not (self._ml <= pt.x <= self._ml + pw and self._mt <= pt.y <= self._mt + ph):
+            event.Skip()
+            return
+        ranges = self._data_ranges()
+        if ranges is None:
+            event.Skip()
+            return
+        x_min, x_max, y_min, y_max = ranges
+        factor = 1.15 ** (-event.GetWheelRotation() / 120.0)
+        mx = x_min + (pt.x - self._ml) / pw * (x_max - x_min)
+        my = y_max - (pt.y - self._mt) / ph * (y_max - y_min)
+        self._zoom_x_min = mx + (x_min - mx) * factor
+        self._zoom_x_max = mx + (x_max - mx) * factor
+        self._zoom_y_min = my + (y_min - my) * factor
+        self._zoom_y_max = my + (y_max - my) * factor
+        self._sync_camera()
+        self.Refresh()
+        event.Skip()
+
+    def _on_right_dclick(self, event: wx.MouseEvent) -> None:
+        """Reset zoom to full data range on right double-click."""
+        self._zoom_x_min = self._zoom_x_max = self._zoom_y_min = self._zoom_y_max = None
+        if self._xs is not None:
+            self._sync_camera()
+        self.Refresh()
+        event.Skip()
+
+    def _on_mouse_move(self, event: wx.MouseEvent) -> None:
+        """Forward panel mouse-move to the shared handler."""
+        self._handle_mouse_move(event.GetPosition(), event)
+
+    def _on_canvas_mouse_move(self, event: wx.MouseEvent) -> None:
+        """Translate canvas mouse-move to panel coordinates and forward."""
+        pt = self._canvas_pt_to_panel(event.GetPosition().x, event.GetPosition().y)
+        self._handle_mouse_move(pt, event)
+
+    def _on_leave(self, event: wx.MouseEvent) -> None:
+        """Clear hover state when the mouse leaves the panel."""
+        self._clear_hover_state()
+        event.Skip()
+
+    def _on_canvas_leave(self, event: wx.MouseEvent) -> None:
+        """Clear hover state when the mouse leaves the canvas."""
+        self._clear_hover_state()
+        event.Skip()
+
+    def _on_mouse_down(self, event: wx.MouseEvent) -> None:
+        """Start pan (plain click) or rubber-band zoom (ctrl+click) on left down."""
+        raw_pt = event.GetPosition()
+        obj = event.GetEventObject()
+        pt = self._canvas_pt_to_panel(raw_pt.x, raw_pt.y) if obj is self._canvas.native else raw_pt
+        if self._xs is None:
+            event.Skip()
+            return
+        if event.ControlDown() and self._panel_pt_in_plot(pt):
+            self._drag_start = self._drag_end = pt
+        else:
+            self._panning = True
+            self._pan_last_pt = pt
+        event.Skip()
+
+    def _on_mouse_up(self, event: wx.MouseEvent) -> None:
+        """Finalise pan or apply rubber-band zoom on left up."""
+        if self._panning:
+            self._panning = False
+            self._pan_last_pt = None
+            event.Skip()
+            return
+        if self._drag_start is not None:
+            raw_pt = event.GetPosition()
+            obj = event.GetEventObject()
+            end = self._canvas_pt_to_panel(raw_pt.x, raw_pt.y) if obj is self._canvas.native else raw_pt
+            start = self._drag_start
+            self._drag_start = self._drag_end = None
+            self._sel_line.visible = False
+            self._canvas.update()
+            ranges = self._data_ranges()
+            if ranges is not None:
+                W, H = self.GetSize()
+                pw = W - self._ml - self._mr
+                ph = H - self._mt - self._mb
+                x_min, x_max, y_min, y_max = ranges
+                sx = sorted([start.x, end.x])
+                sy = sorted([start.y, end.y])
+                if sx[1] - sx[0] > 4 and sy[1] - sy[0] > 4:
+                    self._zoom_x_min = x_min + (sx[0] - self._ml) / pw * (x_max - x_min)
+                    self._zoom_x_max = x_min + (sx[1] - self._ml) / pw * (x_max - x_min)
+                    self._zoom_y_min = y_max - (sy[1] - self._mt) / ph * (y_max - y_min)
+                    self._zoom_y_max = y_max - (sy[0] - self._mt) / ph * (y_max - y_min)
+                    self._sync_camera()
+            self.Refresh()
+            event.Skip()
+            return
+        event.Skip()
+
+    def _on_size(self, event: wx.SizeEvent) -> None:
+        """Reposition the canvas and sync camera on resize."""
+        self._reposition_canvas()
+        if self._xs is not None:
+            self._sync_camera()
+        self.Refresh()
+        event.Skip()
+
+    def _on_paint(self, _: wx.PaintEvent) -> None:
+        """Paint axes, tick labels, axis labels, and subclass overlays using theme colours."""
+        dc = wx.AutoBufferedPaintDC(self)
+        dc.DestroyClippingRegion()
+        gc = wx.GraphicsContext.Create(dc)
+        if gc is None:
+            return
+
+        bg = get_color("bg")
+        border = get_color("graytext")
+        tick_label = get_color("text")
+        axis_label = get_color("text")
+        empty_text = get_color("graytext")
+
+        W, H = self.GetSize()
+        ml, mr, mt, mb = self._ml, self._mr, self._mt, self._mb
+        pw, ph = W - ml - mr, H - mt - mb
+
+        gc.SetBrush(wx.Brush(bg))
+        gc.SetPen(wx.TRANSPARENT_PEN)
+        gc.DrawRectangle(0, 0, ml, H)
+        gc.DrawRectangle(ml, 0, pw, mt)
+        gc.DrawRectangle(ml, mt + ph, pw, mb)
+        gc.DrawRectangle(ml + pw, 0, mr, H)
+
+        gc.SetPen(wx.Pen(border, 1))
+        gc.SetBrush(wx.TRANSPARENT_BRUSH)
+        gc.StrokeLine(ml, mt + ph, ml + pw, mt + ph)
+        gc.StrokeLine(ml, mt, ml, mt + ph)
+
+        font_small = wx.Font(10, wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD)
+        ranges = self._data_ranges()
+
+        if ranges is None:
+            gc.SetBrush(wx.Brush(get_color("bg")))
+            gc.SetPen(wx.TRANSPARENT_PEN)
+            gc.DrawRectangle(ml, mt, pw, ph)
+            gc.SetFont(
+                wx.Font(13, wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD),
+                empty_text,
+            )
+            msg = "No data"
+            tw, th = gc.GetTextExtent(msg)
+            gc.DrawText(msg, ml + pw / 2 - tw / 2, mt + ph / 2 - th / 2)
+        else:
+            x_min, x_max, y_min, y_max = ranges
+
+            gc.SetFont(font_small, tick_label)
+            for i in range(5):
+                t = i / 4
+                y_val = y_min + t * (y_max - y_min)
+                py = mt + ph - t * ph
+                av = abs(y_val)
+                if av == 0:
+                    lbl = "0"
+                elif av >= 1e6 or (0 < av < 0.01):
+                    lbl = f"{y_val:.2e}"
+                elif av >= 1000:
+                    lbl = f"{y_val:,.0f}"
+                elif av >= 10:
+                    lbl = f"{y_val:.1f}"
+                else:
+                    lbl = f"{y_val:.3f}"
+                tw, th = gc.GetTextExtent(lbl)
+                gc.DrawText(lbl, ml - tw - 4, py - th / 2)
+
+            for i in range(5):
+                t = i / 4
+                x_val = x_min + t * (x_max - x_min)
+                px = ml + t * pw
+                gc.SetPen(wx.Pen(border, 1))
+                gc.StrokeLine(px, mt + ph, px, mt + ph + 3)
+                lbl = f"{x_val:.4g}"
+                tw, _ = gc.GetTextExtent(lbl)
+                gc.DrawText(lbl, px - tw / 2, mt + ph + 5)
+
+            gc.SetFont(font_small, axis_label)
+            x_lw, _ = gc.GetTextExtent(self._x_label)
+            gc.DrawText(self._x_label, ml + pw / 2 - x_lw / 2, H - mb + 20)
+
+            y_lw, y_lh = gc.GetTextExtent(self._y_label)
+            gc.PushState()
+            gc.Translate(y_lh, mt + ph / 2 + y_lw / 2)
+            gc.Rotate(-math.pi / 2)
+            gc.DrawText(self._y_label, 0, 0)
+            gc.PopState()
+
+        self.draw_overlays(gc, W, H)

--- a/wxmplot/line_plot.py
+++ b/wxmplot/line_plot.py
@@ -35,7 +35,7 @@ class LinePlot(wx.Panel):
         margin_bottom: int = 50,
     ) -> None:
         """Initialise the LinePlot panel."""
-        super().__init__(parent)
+        super().__init__(parent, style=wx.BORDER_NONE)
         self.SetMinSize((-1, 160))
         self.SetBackgroundStyle(wx.BG_STYLE_PAINT)
 

--- a/wxmplot/line_plot.py
+++ b/wxmplot/line_plot.py
@@ -12,6 +12,7 @@ from typing import Callable
 import numpy as np
 import wx
 from wxutils.colors import get_color, is_dark_theme, register_darkdetect
+from wxutils.themes import get_theme
 
 from wxmplot.vispy_utils import vispy_colour, vispy_init, vsync_for_platform
 
@@ -566,5 +567,12 @@ class LinePlot(wx.Panel):
             gc.Rotate(-math.pi / 2)
             gc.DrawText(self._y_label, 0, 0)
             gc.PopState()
+
+        if self._hover_data_x is not None and self._hover_data_y is not None:
+            hover_font = wx.Font(10, wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD)
+            gc.SetFont(hover_font, get_theme().green)
+            text = self.format_hover_info(self._hover_data_x, self._hover_data_y)
+            tw, th = gc.GetTextExtent(text)
+            gc.DrawText(text, ml + pw - tw - 6, mt + 4)
 
         self.draw_overlays(gc, W, H)

--- a/wxmplot/line_plot.py
+++ b/wxmplot/line_plot.py
@@ -113,12 +113,16 @@ class LinePlot(wx.Panel):
         self.Bind(wx.EVT_LEAVE_WINDOW, self._on_leave)
         self.Bind(wx.EVT_LEFT_DOWN, self._on_mouse_down)
         self.Bind(wx.EVT_LEFT_UP, self._on_mouse_up)
+        self.Bind(wx.EVT_RIGHT_DOWN, self._on_right_down)
+        self.Bind(wx.EVT_RIGHT_UP, self._on_right_up)
         self.Bind(wx.EVT_MOUSEWHEEL, self._on_mouse_wheel)
         self.Bind(wx.EVT_RIGHT_DCLICK, self._on_right_dclick)
 
         self._canvas.native.Bind(wx.EVT_MOUSEWHEEL, self._on_mouse_wheel)
         self._canvas.native.Bind(wx.EVT_LEFT_DOWN, self._on_mouse_down)
         self._canvas.native.Bind(wx.EVT_LEFT_UP, self._on_mouse_up)
+        self._canvas.native.Bind(wx.EVT_RIGHT_DOWN, self._on_right_down)
+        self._canvas.native.Bind(wx.EVT_RIGHT_UP, self._on_right_up)
         self._canvas.native.Bind(wx.EVT_MOTION, self._on_canvas_mouse_move)
         self._canvas.native.Bind(wx.EVT_LEAVE_WINDOW, self._on_canvas_leave)
         self._canvas.native.Bind(wx.EVT_RIGHT_DCLICK, self._on_right_dclick)
@@ -405,6 +409,24 @@ class LinePlot(wx.Panel):
         self.Refresh()
         event.Skip()
 
+    def _on_right_down(self, event: wx.MouseEvent) -> None:
+        """Start pan on right down."""
+        raw_pt = event.GetPosition()
+        obj = event.GetEventObject()
+        pt = self._canvas_pt_to_panel(raw_pt.x, raw_pt.y) if obj is self._canvas.native else raw_pt
+        if self._xs is None:
+            event.Skip()
+            return
+        self._panning = True
+        self._pan_last_pt = pt
+        event.Skip()
+
+    def _on_right_up(self, event: wx.MouseEvent) -> None:
+        """End pan on right up."""
+        self._panning = False
+        self._pan_last_pt = None
+        event.Skip()
+
     def _on_mouse_move(self, event: wx.MouseEvent) -> None:
         """Forward panel mouse-move to the shared handler."""
         self._handle_mouse_move(event.GetPosition(), event)
@@ -425,27 +447,19 @@ class LinePlot(wx.Panel):
         event.Skip()
 
     def _on_mouse_down(self, event: wx.MouseEvent) -> None:
-        """Start pan (plain click) or rubber-band zoom (ctrl+click) on left down."""
+        """Start rubber-band zoom on left down."""
         raw_pt = event.GetPosition()
         obj = event.GetEventObject()
         pt = self._canvas_pt_to_panel(raw_pt.x, raw_pt.y) if obj is self._canvas.native else raw_pt
         if self._xs is None:
             event.Skip()
             return
-        if event.ControlDown() and self._panel_pt_in_plot(pt):
+        if self._panel_pt_in_plot(pt):
             self._drag_start = self._drag_end = pt
-        else:
-            self._panning = True
-            self._pan_last_pt = pt
         event.Skip()
 
     def _on_mouse_up(self, event: wx.MouseEvent) -> None:
-        """Finalise pan or apply rubber-band zoom on left up."""
-        if self._panning:
-            self._panning = False
-            self._pan_last_pt = None
-            event.Skip()
-            return
+        """Apply rubber-band zoom on left up."""
         if self._drag_start is not None:
             raw_pt = event.GetPosition()
             obj = event.GetEventObject()

--- a/wxmplot/line_plot.py
+++ b/wxmplot/line_plot.py
@@ -502,14 +502,16 @@ class LinePlot(wx.Panel):
         gc = wx.GraphicsContext.Create(dc)
         if gc is None:
             return
+        self._draw_axes(gc, *self.GetSize())
 
+    def _draw_axes(self, gc: wx.GraphicsContext, W: int, H: int) -> None:
+        """Draw axes, labels, and overlays into gc at size (W, H)."""
         bg = get_color("bg")
         border = get_color("graytext")
         tick_label = get_color("text")
         axis_label = get_color("text")
         empty_text = get_color("graytext")
 
-        W, H = self.GetSize()
         ml, mr, mt, mb = self._ml, self._mr, self._mt, self._mb
         pw, ph = W - ml - mr, H - mt - mb
 
@@ -590,3 +592,36 @@ class LinePlot(wx.Panel):
             gc.DrawText(text, ml + pw - tw - 6, mt + 4)
 
         self.draw_overlays(gc, W, H)
+
+    def render_to_array(self) -> np.ndarray:
+        """Render the full plot (axes + embedded VisPy curve) to an RGB numpy array."""
+        W, H = self.GetSize()
+        ml, mr, mt, mb = self._ml, self._mr, self._mt, self._mb
+        pw, ph = W - ml - mr, H - mt - mb
+
+        # Axes, labels, overlays using memory DC
+        bmp = wx.Bitmap(W, H)
+        mem_dc = wx.MemoryDC(bmp)
+        mem_dc.SetBackground(wx.Brush(get_color("bg")))
+        mem_dc.Clear()
+        gc = wx.GraphicsContext.Create(mem_dc)
+        if gc is not None:
+            self._draw_axes(gc, W, H)
+        mem_dc.SelectObject(wx.NullBitmap)
+        img = bmp.ConvertToImage()
+        axes_rgb = np.frombuffer(img.GetData(), dtype=np.uint8).reshape(H, W, 3)
+
+        # Embedded VisPy curve using framebuffer readback
+        canvas_rgba = self._canvas.render()
+        canvas_rgb = canvas_rgba[:, :, :3]
+        ch, cw = canvas_rgb.shape[:2]
+        if (ch, cw) != (ph, pw):
+            img_c = wx.Image(cw, ch)
+            img_c.SetData(canvas_rgb.tobytes())
+            img_c = img_c.Scale(pw, ph, wx.IMAGE_QUALITY_HIGH)
+            canvas_rgb = np.frombuffer(img_c.GetData(), dtype=np.uint8).reshape(ph, pw, 3)
+
+        result = axes_rgb.copy()
+        result[mt:mt + ph, ml:ml + pw] = canvas_rgb
+        return result
+

--- a/wxmplot/vispy_utils.py
+++ b/wxmplot/vispy_utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-wxmplot ImageCanvas: shared VisPy utilities used by all wxmplot VisPy widgets
+wxmplot vispy_utils: shared VisPy utilities used by all wxmplot VisPy widgets.
 """
 
 import sys

--- a/wxmplot/vispy_utils.py
+++ b/wxmplot/vispy_utils.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python
+"""
+wxmplot ImageCanvas: shared VisPy utilities used by all wxmplot VisPy widgets
+"""
+
+import sys
+
+import vispy
+from wxutils.colors import get_color
+from wxutils.themes import get_theme
+
+__all__ = ["vispy_init", "vispy_colour", "vsync_for_platform"]
+
+_VISPY_INITIALISED = False
+
+
+def vispy_init() -> None:
+    """Initialise VisPy with the wx backend and the appropriate GL backend for the platform."""
+    global _VISPY_INITIALISED
+    if _VISPY_INITIALISED:
+        return
+    vispy.use(app="wx", gl="glplus" if sys.platform == "win32" else "gl2")
+    _VISPY_INITIALISED = True
+
+
+def vsync_for_platform() -> bool:
+    """Return True on platforms where vsync is safe with the wx GL backend."""
+    return sys.platform != "linux"
+
+
+def vispy_colour(name: str) -> tuple:
+    """Return a theme colour as a normalised (r, g, b, a) float tuple for VisPy.
+
+    Plot-specific names (plot_curve, plot_fill, plot_selection) are resolved
+    from the active ColorTheme. All other names fall back to get_color().
+    """
+    if name == "plot_curve":
+        c = get_theme().blue
+        return (c.Red() / 255, c.Green() / 255, c.Blue() / 255, 1.0)
+    if name == "plot_fill":
+        c = get_theme().blue
+        return (c.Red() / 255, c.Green() / 255, c.Blue() / 255, 30 / 255)
+    if name == "plot_selection":
+        c = get_theme().selection_bg
+        return (c.Red() / 255, c.Green() / 255, c.Blue() / 255, 178 / 255)
+    rgba = get_color(name)
+    return tuple(c / 255 for c in rgba)
+

--- a/wxmplot/vispy_utils.py
+++ b/wxmplot/vispy_utils.py
@@ -6,6 +6,7 @@ wxmplot ImageCanvas: shared VisPy utilities used by all wxmplot VisPy widgets
 import sys
 
 import vispy
+import wx
 from wxutils.colors import get_color
 from wxutils.themes import get_theme
 
@@ -43,6 +44,11 @@ def vispy_colour(name: str) -> tuple:
     if name == "plot_selection":
         c = get_theme().selection_bg
         return (c.Red() / 255, c.Green() / 255, c.Blue() / 255, 178 / 255)
+    theme = get_theme()
+    if hasattr(theme, name):
+        c = getattr(theme, name)
+        if isinstance(c, wx.Colour):
+            return (c.Red() / 255, c.Green() / 255, c.Blue() / 255, 1.0)
     rgba = get_color(name)
     return tuple(c / 255 for c in rgba)
 


### PR DESCRIPTION
- Adds ImageCanvas — a VisPy 2D image viewer with pan/zoom, ROI selection, line ROI, pixel hover stats, FPS overlay, and live binning (none/stride/mean)
- Adds Histogram widget with optional log/sqrt/linear scale, colorbar strip, draggable level handles, and auto-scaling
- Adds dark/light background support, theme-aware hover colors, and live theme switching
- Adds render_to_array for framebuffer readback on both ImageCanvas and LinePlot
- Adds display norm (linear/sqrt/log) to both histogram and image canvas
- Adds pyopegl dependency for OpenGL acceleration